### PR TITLE
Update prerequisites in README files to include node.js 22+

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Throughout the workshop, we reference specific sections for deeper dives on each
 - **VS Code** with GitHub Copilot or MCP extension
 - **Azure CLI** installed and authenticated
 - **Python 3.10+** installed
+- **node.js 22>** installed
 - Basic familiarity with Azure Portal
 - No prior MCP or security expertise required
 

--- a/camps/base-camp/README.md
+++ b/camps/base-camp/README.md
@@ -11,7 +11,7 @@ Experience the risk of unauthenticated MCP servers firsthand. Deploy a vulnerabl
 | | |
 |---|---|
 | **Difficulty** | Beginner |
-| **Prerequisites** | Python 3.11+, uv |
+| **Prerequisites** | Python 3.11+, uv, node.js >=22 |
 | **Tech Stack** | Python, FastMCP, MCP Inspector |
 
 ## What You'll Learn


### PR DESCRIPTION
This pull request updates the documentation to clarify prerequisites for the workshop and the base camp. The main change is the addition of Node.js (version 22 or higher) as a required dependency.

**Documentation updates:**

* Added `node.js 22>` as a prerequisite in the main `README.md` to ensure all participants have the required runtime installed.
* Updated the prerequisites section in `camps/base-camp/README.md` to include `node.js >=22` alongside Python and uv.