### PR TITLE
feat(camp3): Replace llm-content-safety with policy fragment pattern

### DIFF
--- a/camps/camp3-io-security/infra/main.bicep
+++ b/camps/camp3-io-security/infra/main.bicep
@@ -167,6 +167,7 @@ module apim 'modules/apim.bicep' = {
     apimClientAppId: apimClientAppId
     tenantId: tenantId
     mcpAppClientId: mcpAppClientId
+    contentSafetyEndpoint: contentSafety.outputs.endpoint
   }
 }
 

--- a/camps/camp3-io-security/infra/modules/apim.bicep
+++ b/camps/camp3-io-security/infra/modules/apim.bicep
@@ -8,6 +8,7 @@ param managedIdentityClientId string
 param apimClientAppId string = ''
 param tenantId string
 param mcpAppClientId string = ''
+param contentSafetyEndpoint string = ''
 
 resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' = {
   name: name
@@ -82,6 +83,18 @@ resource namedValueMcpAppClientId 'Microsoft.ApiManagement/service/namedValues@2
   properties: {
     displayName: 'mcp-app-client-id'
     value: mcpAppClientId
+    secret: false
+  }
+}
+
+// Named value for Content Safety endpoint (used in policy fragments)
+// Only created if the value is provided
+resource namedValueContentSafety 'Microsoft.ApiManagement/service/namedValues@2024-06-01-preview' = if (!empty(contentSafetyEndpoint)) {
+  parent: apim
+  name: 'content-safety-endpoint'
+  properties: {
+    displayName: 'content-safety-endpoint'
+    value: contentSafetyEndpoint
     secret: false
   }
 }

--- a/camps/camp3-io-security/infra/policies/base-oauth-contentsafety.xml
+++ b/camps/camp3-io-security/infra/policies/base-oauth-contentsafety.xml
@@ -4,7 +4,7 @@
     This policy is the initial state before Camp 3 fixes are applied.
     It includes:
     - OAuth 2.0 validation (from Camp 1)
-    - Azure AI Content Safety (llm-content-safety) - Layer 1
+    - Content Safety with Prompt Shields (Layer 1) via policy fragment
     
     What's MISSING (vulnerable):
     - Advanced injection pattern detection (Layer 2 input)
@@ -14,6 +14,7 @@
     Key learnings:
     - APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate
       (so omit the path in the header value, but include it in the body)
+    - Content safety uses a reusable policy fragment for Prompt Shields integration
 -->
 <policies>
     <inbound>
@@ -34,15 +35,8 @@
             </required-claims>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Content Safety with Prompt Shields (reusable fragment) -->
+        <include-fragment fragment-id="mcp-content-safety" />
         
         <!-- NOTE: No Layer 2 input validation - advanced injections bypass Content Safety! -->
     </inbound>

--- a/camps/camp3-io-security/infra/policies/fragments/mcp-content-safety.xml
+++ b/camps/camp3-io-security/infra/policies/fragments/mcp-content-safety.xml
@@ -1,0 +1,87 @@
+<!--
+  MCP Content Safety Fragment
+  
+  Extracts user input from MCP tools/call requests and checks for prompt injection
+  using Azure Content Safety Prompt Shields API.
+  
+  Prerequisites:
+  - Named value: managed-identity-client-id
+  - Named value: content-safety-endpoint
+  
+  Behavior:
+  - Only checks tools/call requests (other MCP methods pass through)
+  - Extracts all argument values and concatenates for analysis
+  - Returns 400 if prompt injection detected
+  - Passes through if no attack detected or if Content Safety unavailable
+-->
+<fragment>
+  <!-- Save request body for analysis -->
+  <set-variable name="original-body" value="@(context.Request.Body.As<string>(preserveContent: true))" />
+  <!-- Extract MCP arguments as the text to analyze -->
+  <set-variable name="mcp-user-input" value="@{
+    try {
+      var body = JObject.Parse((string)context.Variables["original-body"]);
+      var method = body["method"]?.ToString() ?? "";
+      if (method != "tools/call") { return ""; }
+      var args = body["params"]?["arguments"];
+      if (args == null) { return ""; }
+      var values = new List<string>();
+      foreach (var prop in ((JObject)args).Properties()) {
+        values.Add(prop.Value.ToString());
+      }
+      return string.Join(" ", values);
+    } catch {
+      return "";
+    }
+  }" />
+  <!-- Only run content safety check if we have user input -->
+  <choose>
+    <when condition="@(!string.IsNullOrEmpty((string)context.Variables["mcp-user-input"]))">
+      <!-- Get managed identity token for Content Safety -->
+      <authentication-managed-identity resource="https://cognitiveservices.azure.com/" client-id="{{managed-identity-client-id}}" output-token-variable-name="cs-token" />
+      <!-- Call Content Safety Prompt Shields API -->
+      <send-request mode="new" response-variable-name="cs-response" timeout="10" ignore-error="true">
+        <set-url>{{content-safety-endpoint}}contentsafety/text:shieldPrompt?api-version=2024-09-01</set-url>
+        <set-method>POST</set-method>
+        <set-header name="Authorization" exists-action="override">
+          <value>@("Bearer " + (string)context.Variables["cs-token"])</value>
+        </set-header>
+        <set-header name="Content-Type" exists-action="override">
+          <value>application/json</value>
+        </set-header>
+        <set-body>@{
+          var userInput = (string)context.Variables["mcp-user-input"];
+          return JsonConvert.SerializeObject(new {
+            userPrompt = userInput,
+            documents = new object[] {}
+          });
+        }</set-body>
+      </send-request>
+      <!-- Check if prompt injection was detected -->
+      <choose>
+        <when condition="@{
+          var response = context.Variables.GetValueOrDefault<IResponse>("cs-response");
+          if (response == null || response.StatusCode != 200) { return false; }
+          var body = response.Body.As<JObject>(preserveContent: true);
+          var userAnalysis = body["userPromptAnalysis"];
+          if (userAnalysis == null) { return false; }
+          var attackDetected = userAnalysis["attackDetected"]?.Value<bool>() ?? false;
+          return attackDetected;
+        }">
+          <return-response>
+            <set-status code="400" reason="Bad Request" />
+            <set-header name="Content-Type" exists-action="override">
+              <value>application/json</value>
+            </set-header>
+            <set-body>@{
+              return JsonConvert.SerializeObject(new {
+                error = "content_blocked",
+                message = "Request blocked: potential prompt injection detected"
+              });
+            }</set-body>
+          </return-response>
+        </when>
+      </choose>
+    </when>
+  </choose>
+</fragment>

--- a/camps/camp3-io-security/infra/policies/full-io-security.xml
+++ b/camps/camp3-io-security/infra/policies/full-io-security.xml
@@ -4,13 +4,14 @@
     This policy includes complete defense-in-depth I/O security:
     - OAuth 2.0 validation (from Camp 2)
     - Rate limiting (from Camp 2)
-    - Layer 1: Azure AI Content Safety (llm-content-safety)
+    - Layer 1: Content Safety with Prompt Shields (via policy fragment)
     - Layer 2: Azure Function input_check (advanced injection patterns)
     - Layer 2: Azure Function sanitize_output (PII redaction + credential scanning)
     
     Key learnings:
     - APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate
       (so omit the path in the header value, but include it in the body)
+    - Content safety uses a reusable policy fragment for Prompt Shields integration
 -->
 <policies>
     <inbound>
@@ -29,15 +30,8 @@
             </required-claims>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety (fast, broad filtering) -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Content Safety with Prompt Shields (reusable fragment) -->
+        <include-fragment fragment-id="mcp-content-safety" />
 
         <!-- Layer 2: Advanced Input Check (Azure Function) -->
         <send-request mode="new" response-variable-name="inputCheck" timeout="5" ignore-error="false">

--- a/camps/camp3-io-security/infra/policies/sherpa-mcp-full-io-security.xml
+++ b/camps/camp3-io-security/infra/policies/sherpa-mcp-full-io-security.xml
@@ -5,7 +5,7 @@
     
     Includes:
     - OAuth 2.0 validation (Entra ID)
-    - Layer 1: Azure AI Content Safety
+    - Layer 1: Content Safety with Prompt Shields (via policy fragment)
     - Layer 2: Azure Function input_check (injection detection)
     
     NOTE: Output sanitization (PII redaction) is handled SERVER-SIDE by the MCP server itself.
@@ -15,6 +15,7 @@
     Key learnings:
     - APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate
       (so omit the path in the header value, but include it in the body)
+    - Content safety uses a reusable policy fragment for Prompt Shields integration
 -->
 <policies>
     <inbound>
@@ -33,15 +34,8 @@
             </required-claims>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety (fast, broad filtering) -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Content Safety with Prompt Shields (reusable fragment) -->
+        <include-fragment fragment-id="mcp-content-safety" />
 
         <!-- Layer 2: Advanced Input Check (Azure Function) -->
         <send-request mode="new" response-variable-name="inputCheck" timeout="5" ignore-error="false">

--- a/camps/camp3-io-security/infra/policies/trail-mcp-input-security.xml
+++ b/camps/camp3-io-security/infra/policies/trail-mcp-input-security.xml
@@ -33,15 +33,8 @@
             </required-claims>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety (fast, broad filtering) -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Azure AI Content Safety via Policy Fragment (Prompt Shields) -->
+        <include-fragment fragment-id="mcp-content-safety" />
 
         <!-- Layer 2: Advanced Input Check (Azure Function) -->
         <send-request mode="new" response-variable-name="inputCheck" timeout="5" ignore-error="false">

--- a/camps/camp3-io-security/infra/waypoints/initial-api-setup.bicep
+++ b/camps/camp3-io-security/infra/waypoints/initial-api-setup.bicep
@@ -67,6 +67,21 @@ resource contentSafetyBackend 'Microsoft.ApiManagement/service/backends@2024-06-
 }
 
 // ============================================
+// Policy Fragment: MCP Content Safety (Prompt Shields)
+// Reusable fragment for Layer 1 content safety checks
+// ============================================
+
+resource mcpContentSafetyFragment 'Microsoft.ApiManagement/service/policyFragments@2024-06-01-preview' = {
+  parent: apim
+  name: 'mcp-content-safety'
+  properties: {
+    description: 'Extracts MCP tool arguments and checks for prompt injection using Azure Content Safety Prompt Shields API'
+    format: 'rawxml'
+    value: loadTextContent('../policies/fragments/mcp-content-safety.xml')
+  }
+}
+
+// ============================================
 // Sherpa MCP API (Native MCP Type - Passthrough)
 // ============================================
 
@@ -114,6 +129,9 @@ resource sherpaMcpPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-
       '{{mcp-app-client-id}}', mcpAppClientId),
       '{{apim-gateway-url}}', apim.properties.gatewayUrl)
   }
+  dependsOn: [
+    mcpContentSafetyFragment
+  ]
 }
 
 // Note: Cannot add suffix-pattern PRM operation to MCP type API
@@ -318,6 +336,9 @@ resource trailMcpPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-0
       '{{mcp-app-client-id}}', mcpAppClientId),
       '{{apim-gateway-url}}', apim.properties.gatewayUrl)
   }
+  dependsOn: [
+    mcpContentSafetyFragment
+  ]
 }
 
 // Note: Cannot add suffix-pattern PRM operation to MCP type API

--- a/camps/camp3-io-security/scripts/1.1-exploit-injection.sh
+++ b/camps/camp3-io-security/scripts/1.1-exploit-injection.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Waypoint 1.1: Exploit - Technical Injection Bypass
-# Demonstrates that technical injection patterns bypass Layer 1 (Content Safety)
-# Content Safety with Prompt Shields catches harmful content and jailbreaks,
-# but NOT technical injection patterns like shell commands, SQL, or path traversal.
+# Demonstrates that technical injection patterns bypass Layer 1 (Prompt Shields)
+# Prompt Shields detects AI-specific attacks (prompt injection, jailbreaks) that try
+# to manipulate LLM behavior, but NOT traditional security attacks like shell commands,
+# SQL injection, or path traversal - those require Layer 2 input validation.
 # Usage: ./1.1-exploit-injection.sh [sherpa|trails]
 set -e
 
@@ -25,8 +26,8 @@ APIM_URL=$(azd env get-value APIM_GATEWAY_URL)
 MCP_APP_CLIENT_ID=$(azd env get-value MCP_APP_CLIENT_ID)
 TOKEN=$(az account get-access-token --resource "$MCP_APP_CLIENT_ID" --query accessToken -o tsv)
 
-echo "Content Safety (Layer 1) catches harmful content and jailbreaks."
-echo "But it does NOT detect technical injection patterns."
+echo "Prompt Shields (Layer 1) detects AI prompt injection and jailbreaks."
+echo "But it does NOT detect traditional technical injection patterns."
 echo ""
 
 if [ "$TARGET" = "sherpa" ]; then
@@ -97,6 +98,6 @@ fi
 
 echo ""
 echo "=========================================="
-echo "Layer 1 is NOT designed for technical injection detection."
-echo "This is why we need Layer 2: Input Validation"
+echo "Prompt Shields detects AI manipulation attempts, not technical exploits."
+echo "This is why we need Layer 2: Input Validation (pattern-based detection)"
 echo "=========================================="

--- a/camps/camp3-io-security/scripts/get-mcp-token.sh
+++ b/camps/camp3-io-security/scripts/get-mcp-token.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+set -e
+
+echo "🎫 Camp 3: Get MCP Token for APIM"
+echo "================================="
+echo ""
+
+# Load azd environment variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CAMP_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Try to find the azd environment directory
+if [ -d "${CAMP_DIR}/.azure" ]; then
+    # Find the first non-hidden directory in .azure (the environment name)
+    ENV_DIR=$(find "${CAMP_DIR}/.azure" -mindepth 1 -maxdepth 1 -type d ! -name ".*" | head -1)
+    if [ -n "$ENV_DIR" ] && [ -f "${ENV_DIR}/.env" ]; then
+        echo "📦 Loading environment from ${ENV_DIR}/.env..."
+        source "${ENV_DIR}/.env"
+    else
+        echo "📦 Loading azd environment..."
+        cd "$CAMP_DIR"
+        eval "$(azd env get-values | sed 's/^/export /')"
+    fi
+else
+    echo "📦 Loading azd environment..."
+    cd "$CAMP_DIR"
+    eval "$(azd env get-values | sed 's/^/export /')"
+fi
+
+# Check for required environment variables
+if [ -z "${MCP_APP_CLIENT_ID}" ]; then
+    echo "❌ Error: MCP_APP_CLIENT_ID not found in environment."
+    echo "Make sure you've run 'azd up' first."
+    exit 1
+fi
+
+if [ -z "${APIM_CLIENT_APP_ID}" ]; then
+    echo "❌ Error: APIM_CLIENT_APP_ID not found in environment."
+    exit 1
+fi
+
+if [ -z "${APIM_CLIENT_SECRET}" ]; then
+    echo "❌ Error: APIM_CLIENT_SECRET not found in environment."
+    exit 1
+fi
+
+TENANT_ID=$(az account show --query tenantId -o tsv)
+
+echo "MCP App Client ID:  ${MCP_APP_CLIENT_ID}"
+echo "APIM Client App ID: ${APIM_CLIENT_APP_ID}"
+echo "Tenant ID:          ${TENANT_ID}"
+echo ""
+
+# Parse command line arguments
+FLOW="client_credentials"
+OUTPUT="token"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --pkce)
+            FLOW="pkce"
+            shift
+            ;;
+        --json)
+            OUTPUT="json"
+            shift
+            ;;
+        --export)
+            OUTPUT="export"
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --pkce    Use PKCE flow (interactive browser login)"
+            echo "  --json    Output full token response as JSON"
+            echo "  --export  Output as export command for shell"
+            echo "  --help    Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  $0                    # Get token using client credentials"
+            echo "  $0 --pkce             # Get token using PKCE (user login)"
+            echo "  $0 --export           # Output: export TOKEN=..."
+            echo "  eval \$($0 --export)  # Set TOKEN in current shell"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$FLOW" = "client_credentials" ]; then
+    echo "🔐 Acquiring token using client credentials flow..."
+    echo ""
+    
+    RESPONSE=$(curl -s -X POST "https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "client_id=${APIM_CLIENT_APP_ID}" \
+        -d "client_secret=${APIM_CLIENT_SECRET}" \
+        -d "scope=${MCP_APP_CLIENT_ID}/.default" \
+        -d "grant_type=client_credentials")
+    
+    TOKEN=$(echo "$RESPONSE" | jq -r '.access_token')
+    
+    if [ "$TOKEN" = "null" ] || [ -z "$TOKEN" ]; then
+        echo "❌ Failed to acquire token"
+        echo "$RESPONSE" | jq .
+        exit 1
+    fi
+
+elif [ "$FLOW" = "pkce" ]; then
+    echo "🔐 Acquiring token using PKCE flow (interactive)..."
+    echo "You will be prompted to authenticate in your browser."
+    echo ""
+    
+    # Try using az login with the scope
+    TOKEN=$(az account get-access-token \
+        --resource "${MCP_APP_CLIENT_ID}" \
+        --query accessToken -o tsv 2>&1)
+    
+    if [ $? -ne 0 ] || [ -z "$TOKEN" ]; then
+        echo ""
+        echo "⚠️  Interactive login required. Run:"
+        echo ""
+        echo "  az login --scope ${MCP_APP_CLIENT_ID}/.default"
+        echo ""
+        echo "Then run this script again."
+        exit 1
+    fi
+fi
+
+# Output based on format
+case $OUTPUT in
+    json)
+        echo "$RESPONSE"
+        ;;
+    export)
+        echo "export MCP_TOKEN=\"${TOKEN}\""
+        ;;
+    token)
+        echo "✅ Token acquired successfully!"
+        echo ""
+        echo "Your access token:"
+        echo ""
+        echo "${TOKEN}"
+        echo ""
+        echo "💡 Usage with MCP Inspector:"
+        echo ""
+        echo "  npx @modelcontextprotocol/inspector --transport http \\"
+        echo "    --server-url \"https://\${APIM_NAME}.azure-api.net/sherpa/mcp\" \\"
+        echo "    --header \"Authorization: Bearer \${TOKEN}\""
+        echo ""
+        echo "💡 Usage with curl:"
+        echo ""
+        echo "  curl -X POST \"https://\${APIM_NAME}.azure-api.net/sherpa/mcp\" \\"
+        echo "    -H \"Authorization: Bearer \${TOKEN}\" \\"
+        echo "    -H \"Content-Type: application/json\" \\"
+        echo "    -H \"Accept: application/json, text/event-stream\" \\"
+        echo "    -d '{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",...}'"
+        echo ""
+        echo "💡 Decode token at: https://jwt.ms"
+        echo ""
+        echo "⚠️  Tokens expire after ~1 hour. Run this script again to get a fresh token."
+        ;;
+esac

--- a/docs/camps/camp3-io-security.md
+++ b/docs/camps/camp3-io-security.md
@@ -700,8 +700,8 @@ Now that you've seen the vulnerabilities, let's review the security function cod
 
         ```xml
         <inbound>
-            <!-- Layer 1: Content Safety (existing) -->
-            <llm-content-safety backend-id="content-safety-backend" ... />
+            <!-- Layer 1: Prompt Shields via Policy Fragment -->
+            <include-fragment fragment-id="mcp-content-safety" />
 
             <!-- Layer 2: Advanced Input Check (NEW) -->
             <send-request mode="new" response-variable-name="inputCheck">


### PR DESCRIPTION
- Add mcp-content-safety.xml policy fragment (Prompt Shields API)
- Update all 4 policy files to use include-fragment
- Update initial-api-setup.bicep to create fragment on azd up
- Add contentSafetyEndpoint param to apim.bicep and main.bicep
- Add get-mcp-token.sh helper script
- Update 1.1-exploit-injection.sh comments for clarity
- Update docs to reflect fragment pattern

Aligns camp3 with camp2's PR #16 policy fragment approach.