### PR TITLE
Camp 4: Add two-layer security logging with policy fragments and unified KQL queries

### DIFF
--- a/camps/camp4-monitoring/infra/main.bicep
+++ b/camps/camp4-monitoring/infra/main.bicep
@@ -216,6 +216,7 @@ module apim 'modules/apim.bicep' = {
     apimClientAppId: apimClientAppId
     tenantId: tenantId
     mcpAppClientId: mcpAppClientId
+    contentSafetyEndpoint: contentSafety.outputs.endpoint
     appInsightsId: appInsights.outputs.id
     appInsightsInstrumentationKey: appInsights.outputs.instrumentationKey
   }

--- a/camps/camp4-monitoring/infra/modules/apim.bicep
+++ b/camps/camp4-monitoring/infra/modules/apim.bicep
@@ -9,6 +9,9 @@ param apimClientAppId string = ''
 param tenantId string
 param mcpAppClientId string = ''
 
+@description('Content Safety endpoint for Prompt Shields policy fragment')
+param contentSafetyEndpoint string = ''
+
 @description('Application Insights resource ID for APIM logger')
 param appInsightsId string
 
@@ -88,6 +91,18 @@ resource namedValueMcpAppClientId 'Microsoft.ApiManagement/service/namedValues@2
   properties: {
     displayName: 'mcp-app-client-id'
     value: mcpAppClientId
+    secret: false
+  }
+}
+
+// Named value for Content Safety endpoint (used in policy fragments)
+// Only created if the value is provided
+resource namedValueContentSafety 'Microsoft.ApiManagement/service/namedValues@2024-06-01-preview' = if (!empty(contentSafetyEndpoint)) {
+  parent: apim
+  name: 'content-safety-endpoint'
+  properties: {
+    displayName: 'content-safety-endpoint'
+    value: contentSafetyEndpoint
     secret: false
   }
 }

--- a/camps/camp4-monitoring/infra/modules/workbook.bicep
+++ b/camps/camp4-monitoring/infra/modules/workbook.bicep
@@ -83,7 +83,9 @@ var workbookContent = {
         query: '''
 AppTraces
 | where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend EventType = tostring(Properties.event_type)
+| extend Props = parse_json(Properties)
+| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
+| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
 | where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED')
 | summarize Count=count() by bin(TimeGenerated, 5m), EventType
 | render timechart
@@ -111,9 +113,11 @@ AppTraces
         query: '''
 AppTraces
 | where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend EventType = tostring(Properties.event_type)
+| extend Props = parse_json(Properties)
+| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
+| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
 | where EventType == 'INJECTION_BLOCKED'
-| extend Category = tostring(Properties.category)
+| extend Category = coalesce(tostring(Props.category), tostring(CustomDims.category))
 | summarize Count=count() by Category
 | render piechart
 '''
@@ -134,9 +138,11 @@ AppTraces
         query: '''
 AppTraces
 | where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend EventType = tostring(Properties.event_type)
+| extend Props = parse_json(Properties)
+| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
+| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
 | where EventType == 'PII_REDACTED'
-| extend EntityCount = toint(Properties.entity_count)
+| extend EntityCount = toint(coalesce(Props.entity_count, CustomDims.entity_count))
 | summarize
     TotalEvents = count(),
     TotalEntities = sum(EntityCount)
@@ -164,9 +170,11 @@ AppTraces
         query: '''
 AppTraces
 | where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend EventType = tostring(Properties.event_type)
+| extend Props = parse_json(Properties)
+| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
+| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
 | where EventType == 'INJECTION_BLOCKED'
-| extend ToolName = tostring(Properties.tool_name)
+| extend ToolName = coalesce(tostring(Props.tool_name), tostring(CustomDims.tool_name))
 | where isnotempty(ToolName)
 | summarize Count=count() by ToolName
 | top 10 by Count desc
@@ -188,12 +196,14 @@ AppTraces
         query: '''
 AppTraces
 | where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend EventType = tostring(Properties.event_type)
+| extend Props = parse_json(Properties)
+| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
+| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
 | where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED', 'SECURITY_ERROR')
 | extend
-    Category = tostring(Properties.category),
-    CorrelationId = tostring(Properties.correlation_id),
-    Severity = tostring(Properties.severity)
+    Category = coalesce(tostring(Props.category), tostring(CustomDims.category)),
+    CorrelationId = coalesce(tostring(Props.correlation_id), tostring(CustomDims.correlation_id)),
+    Severity = coalesce(tostring(Props.severity), tostring(CustomDims.severity))
 | project TimeGenerated, EventType, Category, Severity, Message, CorrelationId
 | order by TimeGenerated desc
 | take 50
@@ -244,7 +254,9 @@ AppTraces
         query: '''
 AppTraces
 | where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend EventType = tostring(Properties.event_type)
+| extend Props = parse_json(Properties)
+| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
+| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
 | where EventType == 'SECURITY_ERROR'
 | summarize ErrorCount=count() by bin(TimeGenerated, 5m)
 | render timechart

--- a/camps/camp4-monitoring/infra/policies/base-oauth-contentsafety.xml
+++ b/camps/camp4-monitoring/infra/policies/base-oauth-contentsafety.xml
@@ -4,7 +4,7 @@
     This policy is the initial state before Camp 4 fixes are applied.
     It includes:
     - OAuth 2.0 validation (from Camp 1)
-    - Azure AI Content Safety (llm-content-safety) - Layer 1
+    - Prompt Shields via policy fragment (Layer 1)
     
     What's MISSING (vulnerable):
     - Advanced injection pattern detection (Layer 2 input)
@@ -36,15 +36,8 @@
             </audiences>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Prompt Shields via Policy Fragment -->
+        <include-fragment fragment-id="mcp-content-safety" />
         
         <!-- NOTE: No Layer 2 input validation - advanced injections bypass Content Safety! -->
     </inbound>
@@ -60,5 +53,26 @@
     
     <on-error>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode == 401)">
+                <return-response>
+                    <set-status code="401" reason="Unauthorized" />
+                    <!-- APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate -->
+                    <set-header name="WWW-Authenticate" exists-action="override">
+                        <value>Bearer error="invalid_token", resource_metadata="{{apim-gateway-url}}/.well-known/oauth-protected-resource"</value>
+                    </set-header>
+                    <set-body>@{
+                        var gatewayUrl = "{{apim-gateway-url}}";
+                        var apiPath = context.Api.Path.TrimStart('/');
+                        var prmUrl = gatewayUrl + "/" + apiPath + "/.well-known/oauth-protected-resource";
+                        return JsonConvert.SerializeObject(new {
+                            error = "unauthorized",
+                            message = "Valid OAuth token required",
+                            resource_metadata = prmUrl
+                        });
+                    }</set-body>
+                </return-response>
+            </when>
+        </choose>
     </on-error>
 </policies>

--- a/camps/camp4-monitoring/infra/policies/fragments/mcp-content-safety.xml
+++ b/camps/camp4-monitoring/infra/policies/fragments/mcp-content-safety.xml
@@ -1,0 +1,102 @@
+<!--
+  MCP Content Safety Fragment
+  
+  Extracts user input from MCP tools/call requests and checks for prompt injection
+  using Azure Content Safety Prompt Shields API.
+  
+  Prerequisites:
+  - Named value: managed-identity-client-id
+  - Named value: content-safety-endpoint
+  
+  Behavior:
+  - Only checks tools/call requests (other MCP methods pass through)
+  - Extracts all argument values and concatenates for analysis
+  - Returns 400 if prompt injection detected
+  - Passes through if no attack detected or if Content Safety unavailable
+-->
+<fragment>
+  <!-- Save request body for analysis -->
+  <set-variable name="original-body" value="@(context.Request.Body.As<string>(preserveContent: true))" />
+  <!-- Extract MCP arguments as the text to analyze -->
+  <set-variable name="mcp-user-input" value="@{
+    try {
+      var body = JObject.Parse((string)context.Variables["original-body"]);
+      var method = body["method"]?.ToString() ?? "";
+      if (method != "tools/call") { return ""; }
+      var args = body["params"]?["arguments"];
+      if (args == null) { return ""; }
+      var values = new List<string>();
+      foreach (var prop in ((JObject)args).Properties()) {
+        values.Add(prop.Value.ToString());
+      }
+      return string.Join(" ", values);
+    } catch {
+      return "";
+    }
+  }" />
+  <!-- Only run content safety check if we have user input -->
+  <choose>
+    <when condition="@(!string.IsNullOrEmpty((string)context.Variables["mcp-user-input"]))">
+      <!-- Get managed identity token for Content Safety -->
+      <authentication-managed-identity resource="https://cognitiveservices.azure.com/" client-id="{{managed-identity-client-id}}" output-token-variable-name="cs-token" />
+      <!-- Call Content Safety Prompt Shields API -->
+      <send-request mode="new" response-variable-name="cs-response" timeout="10" ignore-error="true">
+        <set-url>{{content-safety-endpoint}}contentsafety/text:shieldPrompt?api-version=2024-09-01</set-url>
+        <set-method>POST</set-method>
+        <set-header name="Authorization" exists-action="override">
+          <value>@("Bearer " + (string)context.Variables["cs-token"])</value>
+        </set-header>
+        <set-header name="Content-Type" exists-action="override">
+          <value>application/json</value>
+        </set-header>
+        <set-body>@{
+          var userInput = (string)context.Variables["mcp-user-input"];
+          return JsonConvert.SerializeObject(new {
+            userPrompt = userInput,
+            documents = new object[] {}
+          });
+        }</set-body>
+      </send-request>
+      <!-- Check if prompt injection was detected -->
+      <choose>
+        <when condition="@{
+          var response = context.Variables.GetValueOrDefault<IResponse>("cs-response");
+          if (response == null || response.StatusCode != 200) { return false; }
+          var body = response.Body.As<JObject>(preserveContent: true);
+          var userAnalysis = body["userPromptAnalysis"];
+          if (userAnalysis == null) { return false; }
+          var attackDetected = userAnalysis["attackDetected"]?.Value<bool>() ?? false;
+          return attackDetected;
+        }">
+          <!-- Structured logging for prompt injection detection -->
+          <trace source="mcp-content-safety" severity="error">
+            <message>Injection blocked: Prompt injection detected by Prompt Shields</message>
+            <metadata name="event_type" value="INJECTION_BLOCKED" />
+            <metadata name="category" value="prompt_injection" />
+            <metadata name="injection_type" value="prompt_injection" />
+            <metadata name="service" value="apim-content-safety" />
+            <metadata name="correlation_id" value="@(context.RequestId.ToString())" />
+            <metadata name="tool_name" value="@{
+              try {
+                var body = JObject.Parse((string)context.Variables["original-body"]);
+                return body["params"]?["name"]?.ToString() ?? "unknown";
+              } catch { return "unknown"; }
+            }" />
+          </trace>
+          <return-response>
+            <set-status code="400" reason="Bad Request" />
+            <set-header name="Content-Type" exists-action="override">
+              <value>application/json</value>
+            </set-header>
+            <set-body>@{
+              return JsonConvert.SerializeObject(new {
+                error = "content_blocked",
+                message = "Request blocked: potential prompt injection detected"
+              });
+            }</set-body>
+          </return-response>
+        </when>
+      </choose>
+    </when>
+  </choose>
+</fragment>

--- a/camps/camp4-monitoring/infra/policies/full-io-security.xml
+++ b/camps/camp4-monitoring/infra/policies/full-io-security.xml
@@ -4,7 +4,7 @@
     This policy includes complete defense-in-depth I/O security:
     - OAuth 2.0 validation (from Camp 2)
     - Rate limiting (from Camp 2)
-    - Layer 1: Azure AI Content Safety (llm-content-safety)
+    - Layer 1: Prompt Shields via policy fragment
     - Layer 2: Azure Function input_check (advanced injection patterns)
     - Layer 2: Azure Function sanitize_output (PII redaction + credential scanning)
 -->
@@ -31,15 +31,8 @@
             </audiences>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety (fast, broad filtering) -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Prompt Shields via Policy Fragment -->
+        <include-fragment fragment-id="mcp-content-safety" />
 
         <!-- Layer 2: Advanced Input Check (Azure Function) -->
         <send-request mode="new" response-variable-name="inputCheck" timeout="10" ignore-error="false">
@@ -133,5 +126,26 @@
     
     <on-error>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode == 401)">
+                <return-response>
+                    <set-status code="401" reason="Unauthorized" />
+                    <!-- APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate -->
+                    <set-header name="WWW-Authenticate" exists-action="override">
+                        <value>Bearer error="invalid_token", resource_metadata="{{apim-gateway-url}}/.well-known/oauth-protected-resource"</value>
+                    </set-header>
+                    <set-body>@{
+                        var gatewayUrl = "{{apim-gateway-url}}";
+                        var apiPath = context.Api.Path.TrimStart('/');
+                        var prmUrl = gatewayUrl + "/" + apiPath + "/.well-known/oauth-protected-resource";
+                        return JsonConvert.SerializeObject(new {
+                            error = "unauthorized",
+                            message = "Valid OAuth token required",
+                            resource_metadata = prmUrl
+                        });
+                    }</set-body>
+                </return-response>
+            </when>
+        </choose>
     </on-error>
 </policies>

--- a/camps/camp4-monitoring/infra/policies/prm-metadata.xml
+++ b/camps/camp4-monitoring/infra/policies/prm-metadata.xml
@@ -1,0 +1,47 @@
+<!--
+  RFC 9728 Protected Resource Metadata (PRM)
+  Enables OAuth discovery for MCP clients like VS Code
+  
+  This endpoint tells clients:
+  - Which authorization server to use (Entra ID)
+  - What scopes are required
+  - The protected resource URL
+  
+  Key learnings:
+  - Must return-response BEFORE <base /> to skip OAuth validation
+  - Scope format is {appId}/scope_name when identifierUris is empty
+  - VS Code tries multiple discovery paths, both must return the same data
+  
+  NOTE: This is a generic template - the apiPath parameter is replaced at deployment time
+-->
+<policies>
+  <inbound>
+    <!-- Return immediately - do NOT call <base /> which would trigger OAuth validation -->
+    <return-response>
+      <set-status code="200" reason="OK" />
+      <set-header name="Content-Type" exists-action="override">
+        <value>application/json</value>
+      </set-header>
+      <set-header name="Access-Control-Allow-Origin" exists-action="override">
+        <value>*</value>
+      </set-header>
+      <set-body>@{
+        return JsonConvert.SerializeObject(new {
+          resource = "{{apim-gateway-url}}/{{api-path}}",
+          authorization_servers = new[] { "https://login.microsoftonline.com/{{tenant-id}}/v2.0" },
+          bearer_methods_supported = new[] { "header" },
+          scopes_supported = new[] { "{{mcp-app-client-id}}/mcp.access" }
+        });
+      }</set-body>
+    </return-response>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/camps/camp4-monitoring/infra/policies/sherpa-mcp-full-io-security.xml
+++ b/camps/camp4-monitoring/infra/policies/sherpa-mcp-full-io-security.xml
@@ -5,13 +5,17 @@
     
     Includes:
     - OAuth 2.0 validation (Entra ID)
-    - Layer 1: Azure AI Content Safety
+    - Layer 1: Prompt Shields via policy fragment
     - Layer 2: Azure Function input_check (injection detection)
     
     NOTE: Output sanitization (PII redaction) is handled SERVER-SIDE in sherpa-mcp-server.
     This is because MCP Streamable HTTP always returns Content-Type: text/event-stream,
     which requires buffering the full response before sanitization can occur.
     Server-side sanitization avoids APIM buffering and stream interruption issues.
+    
+    Key learnings:
+    - APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate
+      (so omit the path in the header value, but include it in the body)
 -->
 <policies>
     <inbound>
@@ -36,15 +40,8 @@
             </audiences>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety (fast, broad filtering) -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Prompt Shields via Policy Fragment -->
+        <include-fragment fragment-id="mcp-content-safety" />
 
         <!-- Layer 2: Advanced Input Check (Azure Function) -->
         <send-request mode="new" response-variable-name="inputCheck" timeout="10" ignore-error="false">
@@ -116,5 +113,26 @@
     
     <on-error>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode == 401)">
+                <return-response>
+                    <set-status code="401" reason="Unauthorized" />
+                    <!-- APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate -->
+                    <set-header name="WWW-Authenticate" exists-action="override">
+                        <value>Bearer error="invalid_token", resource_metadata="{{apim-gateway-url}}/.well-known/oauth-protected-resource"</value>
+                    </set-header>
+                    <set-body>@{
+                        var gatewayUrl = "{{apim-gateway-url}}";
+                        var apiPath = context.Api.Path.TrimStart('/');
+                        var prmUrl = gatewayUrl + "/" + apiPath + "/.well-known/oauth-protected-resource";
+                        return JsonConvert.SerializeObject(new {
+                            error = "unauthorized",
+                            message = "Valid OAuth token required",
+                            resource_metadata = prmUrl
+                        });
+                    }</set-body>
+                </return-response>
+            </when>
+        </choose>
     </on-error>
 </policies>

--- a/camps/camp4-monitoring/infra/policies/trail-mcp-input-security.xml
+++ b/camps/camp4-monitoring/infra/policies/trail-mcp-input-security.xml
@@ -7,10 +7,14 @@
     
     Includes:
     - OAuth 2.0 validation (Entra ID)
-    - Layer 1: Azure AI Content Safety
+    - Layer 1: Prompt Shields via policy fragment
     - Layer 2: Azure Function input_check (injection detection)
     
     NOTE: Output sanitization is NOT here - it's on trail-api policy
+    
+    Key learnings:
+    - APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate
+      (so omit the path in the header value, but include it in the body)
 -->
 <policies>
     <inbound>
@@ -35,15 +39,8 @@
             </audiences>
         </validate-azure-ad-token>
 
-        <!-- Layer 1: Azure AI Content Safety (fast, broad filtering) -->
-        <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
-            <categories output-type="EightSeverityLevels">
-                <category name="Hate" threshold="4" />
-                <category name="Violence" threshold="4" />
-                <category name="Sexual" threshold="4" />
-                <category name="SelfHarm" threshold="4" />
-            </categories>
-        </llm-content-safety>
+        <!-- Layer 1: Prompt Shields via Policy Fragment -->
+        <include-fragment fragment-id="mcp-content-safety" />
 
         <!-- Layer 2: Advanced Input Check (Azure Function) -->
         <send-request mode="new" response-variable-name="inputCheck" timeout="10" ignore-error="false">
@@ -112,5 +109,26 @@
     
     <on-error>
         <base />
+        <choose>
+            <when condition="@(context.Response.StatusCode == 401)">
+                <return-response>
+                    <set-status code="401" reason="Unauthorized" />
+                    <!-- APIM native MCP type auto-prepends API path to resource_metadata URLs in WWW-Authenticate -->
+                    <set-header name="WWW-Authenticate" exists-action="override">
+                        <value>Bearer error="invalid_token", resource_metadata="{{apim-gateway-url}}/.well-known/oauth-protected-resource"</value>
+                    </set-header>
+                    <set-body>@{
+                        var gatewayUrl = "{{apim-gateway-url}}";
+                        var apiPath = context.Api.Path.TrimStart('/');
+                        var prmUrl = gatewayUrl + "/" + apiPath + "/.well-known/oauth-protected-resource";
+                        return JsonConvert.SerializeObject(new {
+                            error = "unauthorized",
+                            message = "Valid OAuth token required",
+                            resource_metadata = prmUrl
+                        });
+                    }</set-body>
+                </return-response>
+            </when>
+        </choose>
     </on-error>
 </policies>

--- a/camps/camp4-monitoring/infra/waypoints/initial-api-setup.bicep
+++ b/camps/camp4-monitoring/infra/waypoints/initial-api-setup.bicep
@@ -70,6 +70,21 @@ resource contentSafetyBackend 'Microsoft.ApiManagement/service/backends@2024-06-
   }
 }
 
+// ============================================
+// Policy Fragment: MCP Content Safety (Prompt Shields)
+// Reusable fragment for Layer 1 content safety checks
+// ============================================
+
+resource mcpContentSafetyFragment 'Microsoft.ApiManagement/service/policyFragments@2024-06-01-preview' = {
+  parent: apim
+  name: 'mcp-content-safety'
+  properties: {
+    description: 'Extracts MCP tool arguments and checks for prompt injection using Azure Content Safety Prompt Shields API'
+    format: 'rawxml'
+    value: loadTextContent('../policies/fragments/mcp-content-safety.xml')
+  }
+}
+
 // Named Value: Function App URL (for Layer 2 policies)
 // This is the URL that policies use - starts pointing to v1, workshop swaps to v2
 resource namedValueFunctionUrl 'Microsoft.ApiManagement/service/namedValues@2024-06-01-preview' = {
@@ -148,12 +163,13 @@ resource sherpaMcpPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-
   name: 'policy'
   properties: {
     format: 'rawxml'
-    value: replace(replace(
+    value: replace(replace(replace(
       loadTextContent('../policies/sherpa-mcp-full-io-security.xml'),
       '{{tenant-id}}', tenantId),
-      '{{mcp-app-client-id}}', mcpAppClientId)
+      '{{mcp-app-client-id}}', mcpAppClientId),
+      '{{apim-gateway-url}}', apim.properties.gatewayUrl)
   }
-  dependsOn: [namedValueFunctionUrl]
+  dependsOn: [namedValueFunctionUrl, mcpContentSafetyFragment]
 }
 
 // ============================================
@@ -341,12 +357,86 @@ resource trailMcpPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-0
   name: 'policy'
   properties: {
     format: 'rawxml'
-    value: replace(replace(
+    value: replace(replace(replace(
       loadTextContent('../policies/trail-mcp-input-security.xml'),
       '{{tenant-id}}', tenantId),
-      '{{mcp-app-client-id}}', mcpAppClientId)
+      '{{mcp-app-client-id}}', mcpAppClientId),
+      '{{apim-gateway-url}}', apim.properties.gatewayUrl)
   }
-  dependsOn: [namedValueFunctionUrl]
+  dependsOn: [namedValueFunctionUrl, mcpContentSafetyFragment]
+}
+
+// ============================================
+// OAuth PRM Discovery API (RFC 9728)
+// Enables VS Code MCP OAuth discovery
+// ============================================
+
+// OAuth PRM API for RFC 9728 path-based discovery
+resource oauthPrmApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
+  parent: apim
+  name: 'oauth-prm'
+  properties: {
+    displayName: 'OAuth Protected Resource Metadata'
+    description: 'RFC 9728 Protected Resource Metadata for OAuth discovery'
+    path: ''  // Root path
+    protocols: ['https']
+    subscriptionRequired: false
+    apiType: 'http'
+  }
+}
+
+// PRM operation for Sherpa MCP (RFC 9728 path-based discovery)
+resource oauthPrmSherpaMcpOperation 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  parent: oauthPrmApi
+  name: 'get-prm-sherpa-mcp'
+  properties: {
+    displayName: 'Get PRM for Sherpa MCP'
+    description: 'RFC 9728 path-based discovery for /sherpa/mcp resource'
+    method: 'GET'
+    urlTemplate: '/.well-known/oauth-protected-resource/sherpa/mcp'
+  }
+}
+
+// Policy for Sherpa MCP PRM discovery
+resource oauthPrmSherpaMcpPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2024-06-01-preview' = {
+  parent: oauthPrmSherpaMcpOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: replace(replace(replace(replace(
+      loadTextContent('../policies/prm-metadata.xml'),
+      '{{tenant-id}}', tenantId),
+      '{{mcp-app-client-id}}', mcpAppClientId),
+      '{{apim-gateway-url}}', apim.properties.gatewayUrl),
+      '{{api-path}}', 'sherpa/mcp')
+  }
+}
+
+// PRM operation for Trail MCP (RFC 9728 path-based discovery)
+resource oauthPrmTrailMcpOperation 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  parent: oauthPrmApi
+  name: 'get-prm-trail-mcp'
+  properties: {
+    displayName: 'Get PRM for Trail MCP'
+    description: 'RFC 9728 path-based discovery for /trails/mcp resource'
+    method: 'GET'
+    urlTemplate: '/.well-known/oauth-protected-resource/trails/mcp'
+  }
+}
+
+// Policy for Trail MCP PRM discovery
+resource oauthPrmTrailMcpPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2024-06-01-preview' = {
+  parent: oauthPrmTrailMcpOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: replace(replace(replace(replace(
+      loadTextContent('../policies/prm-metadata.xml'),
+      '{{tenant-id}}', tenantId),
+      '{{mcp-app-client-id}}', mcpAppClientId),
+      '{{apim-gateway-url}}', apim.properties.gatewayUrl),
+      '{{api-path}}', 'trails/mcp')
+  }
 }
 
 // ============================================

--- a/camps/camp4-monitoring/infra/workbooks/mcp-security-dashboard.json
+++ b/camps/camp4-monitoring/infra/workbooks/mcp-security-dashboard.json
@@ -47,7 +47,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend EventType = tostring(Properties.event_type)\n| where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED')\n| summarize Count=count() by bin(TimeGenerated, 5m), EventType\n| render timechart",
+        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend Props = parse_json(Properties)\n| extend EventType = coalesce(tostring(Props.event_type), tostring(parse_json(tostring(Props.custom_dimensions)).event_type))\n| where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED')\n| summarize Count=count() by bin(TimeGenerated, 5m), EventType\n| render timechart",
         "size": 0,
         "title": "Security Events Over Time",
         "queryType": 0,
@@ -67,7 +67,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend EventType = tostring(Properties.event_type)\n| where EventType == 'INJECTION_BLOCKED'\n| extend Category = tostring(Properties.category)\n| summarize Count=count() by Category\n| render piechart",
+        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend Props = parse_json(Properties)\n| extend EventType = coalesce(tostring(Props.event_type), tostring(parse_json(tostring(Props.custom_dimensions)).event_type))\n| where EventType == 'INJECTION_BLOCKED'\n| extend Category = coalesce(tostring(Props.category), tostring(parse_json(tostring(Props.custom_dimensions)).category))\n| summarize Count=count() by Category\n| render piechart",
         "size": 1,
         "title": "Blocked Attacks by Category",
         "queryType": 0,
@@ -81,7 +81,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend EventType = tostring(Properties.event_type)\n| where EventType == 'PII_REDACTED'\n| extend EntityCount = toint(Properties.entity_count)\n| summarize TotalEvents = count(), TotalEntities = sum(EntityCount)\n| project strcat('📊 PII Events: ', TotalEvents), strcat('🔒 Entities Redacted: ', TotalEntities)",
+        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend Props = parse_json(Properties)\n| extend EventType = coalesce(tostring(Props.event_type), tostring(parse_json(tostring(Props.custom_dimensions)).event_type))\n| where EventType == 'PII_REDACTED'\n| extend EntityCount = toint(coalesce(Props.entity_count, parse_json(tostring(Props.custom_dimensions)).entity_count))\n| summarize TotalEvents = count(), TotalEntities = sum(EntityCount)\n| project strcat('📊 PII Events: ', TotalEvents), strcat('🔒 Entities Redacted: ', TotalEntities)",
         "size": 3,
         "title": "PII Redaction Summary",
         "queryType": 0,
@@ -98,7 +98,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend EventType = tostring(Properties.event_type)\n| where EventType == 'INJECTION_BLOCKED'\n| extend ToolName = tostring(Properties.tool_name)\n| where isnotempty(ToolName)\n| summarize Count=count() by ToolName\n| top 10 by Count desc\n| render barchart",
+        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend Props = parse_json(Properties)\n| extend EventType = coalesce(tostring(Props.event_type), tostring(parse_json(tostring(Props.custom_dimensions)).event_type))\n| where EventType == 'INJECTION_BLOCKED'\n| extend ToolName = coalesce(tostring(Props.tool_name), tostring(parse_json(tostring(Props.custom_dimensions)).tool_name))\n| where isnotempty(ToolName)\n| summarize Count=count() by ToolName\n| top 10 by Count desc\n| render barchart",
         "size": 0,
         "title": "Attack Trends by MCP Tool",
         "queryType": 0,
@@ -111,7 +111,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend EventType = tostring(Properties.event_type)\n| where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED', 'SECURITY_ERROR')\n| extend Category = tostring(Properties.category), CorrelationId = tostring(Properties.correlation_id), Severity = tostring(Properties.severity)\n| project TimeGenerated, EventType, Category, Severity, Message, CorrelationId\n| order by TimeGenerated desc\n| take 50",
+        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend Props = parse_json(Properties)\n| extend EventType = coalesce(tostring(Props.event_type), tostring(parse_json(tostring(Props.custom_dimensions)).event_type))\n| where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED', 'SECURITY_ERROR')\n| extend Category = coalesce(tostring(Props.category), tostring(parse_json(tostring(Props.custom_dimensions)).category))\n| extend CorrelationId = coalesce(tostring(Props.correlation_id), tostring(parse_json(tostring(Props.custom_dimensions)).correlation_id))\n| extend Severity = coalesce(tostring(Props.severity), tostring(parse_json(tostring(Props.custom_dimensions)).severity))\n| project TimeGenerated, EventType, Category, Severity, Message, CorrelationId\n| order by TimeGenerated desc\n| take 50",
         "size": 0,
         "title": "Recent Security Events",
         "queryType": 0,
@@ -154,7 +154,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend EventType = tostring(Properties.event_type)\n| where EventType == 'SECURITY_ERROR'\n| summarize ErrorCount=count() by bin(TimeGenerated, 5m)\n| render timechart",
+        "query": "AppTraces\n| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}\n| extend Props = parse_json(Properties)\n| extend EventType = coalesce(tostring(Props.event_type), tostring(parse_json(tostring(Props.custom_dimensions)).event_type))\n| where EventType == 'SECURITY_ERROR'\n| summarize ErrorCount=count() by bin(TimeGenerated, 5m)\n| render timechart",
         "size": 0,
         "title": "Security Function Error Rate",
         "queryType": 0,


### PR DESCRIPTION
## Summary

Aligns Camp 4 with the policy fragment pattern from Camp 2, adds structured logging for prompt injection attacks blocked at Layer 1 (APIM), and updates documentation to explain the two-layer blocking architecture.

## Changes

### Infrastructure
- **New `mcp-content-safety.xml` policy fragment** - Encapsulates Prompt Shields integration with `<trace>` policy for structured logging to AppTraces
- **New `prm-metadata.xml`** - RFC 9728 OAuth Protected Resource Metadata for VS Code autodiscovery
- **Updated APIM policies** - Refactored to use `<include-fragment>` pattern for reusability

### Monitoring
- **Workbook KQL queries** - Updated all queries with `coalesce()` pattern to handle both Layer 1 (APIM) and Layer 2 (Function) log formats
- **Fixed workbook generation script** - Changed `let` statements to `extend` (Azure Workbooks don't support `let` in KQL)

### Documentation
- **Two-layer blocking architecture** - Added diagrams and tables explaining:
  - Layer 1 (APIM/Prompt Shields): Blocks prompt injection, logs to `Properties.event_type`
  - Layer 2 (Security Function): Blocks SQL/path/shell injection, logs to `Properties.custom_dimensions.event_type`
- **Unified KQL query patterns** - Updated all query examples to capture ALL attack types using `coalesce()`
- **Updated troubleshooting FAQ** - Explains different log formats for each layer

## Why These Changes?

Previously, prompt injection attacks were blocked by Prompt Shields at Layer 1 but weren't logged with structured metadata, making them invisible in dashboards. The `<trace>` policy now emits structured events that match the same schema as Layer 2 logs, enabling unified security monitoring across all attack types.

## Testing

- ✅ All 4 attack types blocked (SQL, path traversal, shell, prompt injection)
- ✅ All 4 attack types visible in AppTraces with structured logging
- ✅ Dashboard workbook displays all attack categories
- ✅ KQL queries return results from both layers