### PR TITLE
Camp 4: Fix dashboard/alerts and add DEPLOY_MODE=complete

### DIFF
--- a/camps/camp4-monitoring/infra/main.bicep
+++ b/camps/camp4-monitoring/infra/main.bicep
@@ -26,6 +26,9 @@ param apimClientAppId string = ''
 @description('Unique resource suffix - set by preprovision hook via RESOURCE_SUFFIX env var')
 param resourceSuffix string = ''
 
+@description('Deploy mode: "complete" deploys the fully-configured monitoring stack (v2 active, workbook, alerts). Default deploys the workshop starting state.')
+param deployMode string = ''
+
 // Suffix MUST be provided by preprovision hook to avoid soft-delete conflicts.
 // The fallback using deployment().name is only for manual deployments and may cause issues.
 var effectiveSuffix = !empty(resourceSuffix) ? resourceSuffix : substring(uniqueString(resourceGroup().id, deployment().name), 0, 5)
@@ -248,13 +251,47 @@ module apimDiagnostics 'modules/apim-diagnostics.bicep' = {
   }
 }
 
-// NOTE: Azure Monitor Workbook and Action Group are NOT deployed here - they are created by
-// workshop scripts (3.1-deploy-workbook.sh, 3.2-create-alerts.sh) as part of the 
+// In default (workshop) mode, Workbook and Alerts are NOT deployed here — they are created
+// by workshop scripts (3.1-deploy-workbook.sh, 3.2-create-alerts.sh) as part of the
 // "visible → actionable" learning progression in Section 3.
-// 
-// APIM Diagnostic Settings ARE deployed (apim-diagnostics module above) so that
-// ApiManagementGatewayLogs is available immediately. Section 1 focuses on understanding
-// and querying these logs rather than enabling them.
+//
+// In "complete" mode (DEPLOY_MODE=complete), all monitoring resources are deployed
+// automatically: workbook, action group, and alert rules. This is useful for blog posts,
+// demos, or when you want the fully-configured stack without the step-by-step workshop.
+//
+// APIM Diagnostic Settings ARE deployed in both modes (apim-diagnostics module above).
+
+// --- Complete mode: Workbook, Action Group, Alert Rules ---
+
+module workbook 'modules/workbook.bicep' = if (deployMode == 'complete') {
+  name: 'workbook'
+  params: {
+    name: 'wb-${prefix}'
+    location: location
+    tags: tags
+    logAnalyticsWorkspaceId: logAnalytics.outputs.id
+    appInsightsId: appInsights.outputs.id
+  }
+}
+
+module actionGroup 'modules/action-group.bicep' = if (deployMode == 'complete') {
+  name: 'action-group'
+  params: {
+    name: 'ag-${prefix}'
+    tags: tags
+  }
+}
+
+module alertRules 'modules/alert-rules.bicep' = if (deployMode == 'complete') {
+  name: 'alert-rules'
+  params: {
+    namePrefix: 'alert-${prefix}'
+    location: location
+    tags: tags
+    logAnalyticsWorkspaceId: logAnalytics.outputs.id
+    actionGroupId: actionGroup.outputs.id
+  }
+}
 
 // Outputs for azd and waypoint scripts
 output AZURE_RESOURCE_GROUP string = resourceGroup().name
@@ -285,3 +322,4 @@ output LOG_ANALYTICS_WORKSPACE_NAME string = logAnalytics.outputs.name
 // NOTE: WORKBOOK_ID and ACTION_GROUP_ID removed - created by workshop scripts, not Bicep
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = appInsights.outputs.connectionString
 output APPLICATIONINSIGHTS_NAME string = appInsights.outputs.name
+output DEPLOY_MODE string = deployMode

--- a/camps/camp4-monitoring/infra/main.parameters.json
+++ b/camps/camp4-monitoring/infra/main.parameters.json
@@ -19,6 +19,9 @@
     },
     "resourceSuffix": {
       "value": "${RESOURCE_SUFFIX=}"
+    },
+    "deployMode": {
+      "value": "${DEPLOY_MODE=}"
     }
   }
 }

--- a/camps/camp4-monitoring/infra/modules/alert-rules.bicep
+++ b/camps/camp4-monitoring/infra/modules/alert-rules.bicep
@@ -38,7 +38,8 @@ AppTraces
 | where EventType == 'INJECTION_BLOCKED'
 | summarize Count = count()
 '''
-          timeAggregation: 'Count'
+          timeAggregation: 'Total'
+          metricMeasureColumn: 'Count'
           operator: 'GreaterThan'
           threshold: 10
           failingPeriods: {
@@ -136,7 +137,8 @@ AppTraces
 | where EventType == 'SECURITY_ERROR'
 | summarize Count = count()
 '''
-          timeAggregation: 'Count'
+          timeAggregation: 'Total'
+          metricMeasureColumn: 'Count'
           operator: 'GreaterThan'
           threshold: 3
           failingPeriods: {
@@ -184,7 +186,8 @@ AppTraces
 | where EventType == 'CREDENTIAL_DETECTED'
 | summarize Count = count()
 '''
-          timeAggregation: 'Count'
+          timeAggregation: 'Total'
+          metricMeasureColumn: 'Count'
           operator: 'GreaterThan'
           threshold: 0
           failingPeriods: {

--- a/camps/camp4-monitoring/infra/modules/workbook.bicep
+++ b/camps/camp4-monitoring/infra/modules/workbook.bicep
@@ -75,35 +75,57 @@ var workbookContent = {
       }
       name: 'parameters'
     }
-    // Panel 1: Security Events Over Time
+    // Panel 1: Security Summary Scorecards
     {
       type: 3
       content: {
         version: 'KqlItem/1.0'
         query: '''
-AppTraces
+let data = AppTraces
 | where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
 | extend Props = parse_json(Properties)
 | extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
 | extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
-| where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED')
-| summarize Count=count() by bin(TimeGenerated, 5m), EventType
-| render timechart
+| where EventType in ('INJECTION_BLOCKED', 'PII_REDACTED', 'CREDENTIAL_DETECTED', 'SECURITY_ERROR')
+| summarize Count=count() by EventType;
+datatable(EventType:string, SortOrder:int, Label:string)[
+    'INJECTION_BLOCKED', 1, '🛡️ Injections Blocked',
+    'PII_REDACTED', 2, '🔒 PII Redacted',
+    'CREDENTIAL_DETECTED', 3, '⚠️ Credentials Detected',
+    'SECURITY_ERROR', 4, '❌ Security Errors'
+]
+| join kind=leftouter data on EventType
+| project Label, Count = coalesce(Count, 0), SortOrder
+| order by SortOrder asc
 '''
-        size: 0
-        title: 'Security Events Over Time'
+        size: 4
+        title: 'Security Summary'
         queryType: 0
         resourceType: 'microsoft.operationalinsights/workspaces'
-        visualization: 'timechart'
-        chartSettings: {
-          seriesLabelSettings: [
-            { seriesName: 'INJECTION_BLOCKED', color: 'red' }
-            { seriesName: 'PII_REDACTED', color: 'blue' }
-            { seriesName: 'CREDENTIAL_DETECTED', color: 'orange' }
-          ]
+        visualization: 'tiles'
+        tileSettings: {
+          titleContent: {
+            columnMatch: 'Label'
+            formatter: 1
+          }
+          leftContent: {
+            columnMatch: 'Count'
+            formatter: 12
+            formatOptions: {
+              palette: 'auto'
+            }
+            numberFormat: {
+              unit: 17
+              options: {
+                style: 'decimal'
+                maximumFractionDigits: 0
+              }
+            }
+          }
+          showBorder: true
         }
       }
-      name: 'securityEventsTimechart'
+      name: 'securitySummary'
     }
     // Panel 2: Blocked Attacks by Category (Pie Chart)
     {
@@ -127,42 +149,9 @@ AppTraces
         resourceType: 'microsoft.operationalinsights/workspaces'
         visualization: 'piechart'
       }
-      customWidth: '50'
       name: 'attacksByCategory'
     }
-    // Panel 3: PII Redaction Summary (Stat Tiles)
-    {
-      type: 3
-      content: {
-        version: 'KqlItem/1.0'
-        query: '''
-AppTraces
-| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend Props = parse_json(Properties)
-| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
-| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
-| where EventType == 'PII_REDACTED'
-| extend EntityCount = toint(coalesce(Props.entity_count, CustomDims.entity_count))
-| summarize
-    TotalEvents = count(),
-    TotalEntities = sum(EntityCount)
-| project
-    strcat('📊 PII Events: ', TotalEvents),
-    strcat('🔒 Entities Redacted: ', TotalEntities)
-'''
-        size: 3
-        title: 'PII Redaction Summary'
-        queryType: 0
-        resourceType: 'microsoft.operationalinsights/workspaces'
-        visualization: 'tiles'
-        tileSettings: {
-          showBorder: true
-        }
-      }
-      customWidth: '50'
-      name: 'piiSummary'
-    }
-    // Panel 4: Attack Trends by Tool
+    // Panel 3: Attack Trends by Tool
     {
       type: 3
       content: {
@@ -203,7 +192,14 @@ AppTraces
 | extend
     Category = coalesce(tostring(Props.category), tostring(CustomDims.category)),
     CorrelationId = coalesce(tostring(Props.correlation_id), tostring(CustomDims.correlation_id)),
-    Severity = coalesce(tostring(Props.severity), tostring(CustomDims.severity))
+    Severity = case(
+        isnotnull(Props.severity), tostring(Props.severity),
+        isnotnull(CustomDims.severity), tostring(CustomDims.severity),
+        SeverityLevel == 4, 'CRITICAL',
+        SeverityLevel == 3, 'ERROR',
+        SeverityLevel == 2, 'WARNING',
+        'INFO'
+    )
 | project TimeGenerated, EventType, Category, Severity, Message, CorrelationId
 | order by TimeGenerated desc
 | take 50
@@ -235,9 +231,11 @@ AppTraces
               formatOptions: {
                 thresholdsOptions: 'colors'
                 thresholdsGrid: [
+                  { operator: '==', thresholdValue: 'CRITICAL', representation: 'redDark', text: '{0}{1}' }
                   { operator: '==', thresholdValue: 'ERROR', representation: 'red', text: '{0}{1}' }
                   { operator: '==', thresholdValue: 'WARNING', representation: 'orange', text: '{0}{1}' }
-                  { operator: 'Default', representation: 'green', text: '{0}{1}' }
+                  { operator: '==', thresholdValue: 'INFO', representation: 'blue', text: '{0}{1}' }
+                  { operator: 'Default', representation: 'gray', text: '{0}{1}' }
                 ]
               }
             }
@@ -245,34 +243,6 @@ AppTraces
         }
       }
       name: 'recentEvents'
-    }
-    // Panel 6: Error Rate
-    {
-      type: 3
-      content: {
-        version: 'KqlItem/1.0'
-        query: '''
-AppTraces
-| where TimeGenerated >= {TimeRange:start} and TimeGenerated <= {TimeRange:end}
-| extend Props = parse_json(Properties)
-| extend CustomDims = parse_json(replace_string(replace_string(tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
-| extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
-| where EventType == 'SECURITY_ERROR'
-| summarize ErrorCount=count() by bin(TimeGenerated, 5m)
-| render timechart
-'''
-        size: 0
-        title: 'Security Function Error Rate'
-        queryType: 0
-        resourceType: 'microsoft.operationalinsights/workspaces'
-        visualization: 'timechart'
-        chartSettings: {
-          seriesLabelSettings: [
-            { seriesName: 'ErrorCount', color: 'red' }
-          ]
-        }
-      }
-      name: 'errorRate'
     }
   ]
   isLocked: false

--- a/camps/camp4-monitoring/infra/policies/fragments/mcp-content-safety.xml
+++ b/camps/camp4-monitoring/infra/policies/fragments/mcp-content-safety.xml
@@ -74,6 +74,7 @@
             <metadata name="event_type" value="INJECTION_BLOCKED" />
             <metadata name="category" value="prompt_injection" />
             <metadata name="injection_type" value="prompt_injection" />
+            <metadata name="severity" value="WARNING" />
             <metadata name="service" value="apim-content-safety" />
             <metadata name="correlation_id" value="@(context.RequestId.ToString())" />
             <metadata name="tool_name" value="@{

--- a/camps/camp4-monitoring/scripts/hooks/postprovision.sh
+++ b/camps/camp4-monitoring/scripts/hooks/postprovision.sh
@@ -27,6 +27,18 @@ FUNCTION_APP_NAME=$(azd env get-value FUNCTION_APP_NAME)
 FUNCTION_APP_URL=$(azd env get-value FUNCTION_APP_URL)
 FUNCTION_APP_V1_URL=$(azd env get-value FUNCTION_APP_V1_URL)
 FUNCTION_APP_V2_URL=$(azd env get-value FUNCTION_APP_V2_URL)
+
+# Check deploy mode - "complete" deploys the fully-configured stack
+DEPLOY_MODE=$(azd env get-value DEPLOY_MODE 2>/dev/null || echo "")
+
+# In complete mode, APIM routes to v2 (structured logging) from the start
+if [ "$DEPLOY_MODE" = "complete" ]; then
+    ACTIVE_FUNCTION_URL="$FUNCTION_APP_V2_URL"
+    ACTIVE_LABEL="v2 (structured logging)"
+else
+    ACTIVE_FUNCTION_URL="$FUNCTION_APP_V1_URL"
+    ACTIVE_LABEL="v1 (basic logging)"
+fi
 SHERPA_SERVER_URL=$(azd env get-value SHERPA_SERVER_URL)
 TRAIL_API_URL=$(azd env get-value TRAIL_API_URL)
 
@@ -48,8 +60,9 @@ echo "  Resource Group: $RG_NAME"
 echo "  ACR: $ACR_NAME"
 echo "  APIM: $APIM_NAME"
 echo "  Gateway URL: $APIM_GATEWAY_URL"
-echo "  Function v1: $FUNCTION_APP_V1_URL (basic logging - ACTIVE)"
+echo "  Function v1: $FUNCTION_APP_V1_URL (basic logging)"
 echo "  Function v2: $FUNCTION_APP_V2_URL (structured logging)"
+echo "  Active:      $ACTIVE_LABEL"
 echo "  Function URL: $FUNCTION_APP_URL"
 echo "  Sherpa Server: $SHERPA_SERVER_URL"
 echo "  Trail API: $TRAIL_API_URL"
@@ -69,7 +82,7 @@ az deployment group create \
         contentSafetyEndpoint="$CONTENT_SAFETY_ENDPOINT" \
         tenantId="$TENANT_ID" \
         mcpAppClientId="$MCP_APP_CLIENT_ID" \
-        functionAppUrl="$FUNCTION_APP_V1_URL" \
+        functionAppUrl="$ACTIVE_FUNCTION_URL" \
         functionAppV1Url="$FUNCTION_APP_V1_URL" \
         functionAppV2Url="$FUNCTION_APP_V2_URL" \
     --output none
@@ -85,46 +98,73 @@ if [ -n "$MCP_APP_CLIENT_ID" ] && [ -n "$APIM_GATEWAY_URL" ]; then
 fi
 
 echo ""
-echo "=========================================="
+echo "========================================="
 echo "Post-provision Complete"
-echo "=========================================="
+echo "========================================="
 echo ""
 echo "Infrastructure deployed successfully!"
 echo ""
 echo "Camp 4: Monitoring & Telemetry"
 echo "=============================="
 echo ""
-echo "What's deployed:"
-echo "  - APIM with full I/O security (Layer 1 + Layer 2)"
-echo "  - Sherpa MCP Server (Container App)"
-echo "  - Trail API with PII endpoint (Container App)"
-echo "  - Security Function v1 (basic logging - ACTIVE)"
-echo "  - Security Function v2 (structured logging - deployed, not active)"
-echo "  - Log Analytics workspace (not yet connected to APIM)"
-echo ""
-echo "Security layers enabled:"
-echo "  - Layer 1: OAuth + Content Safety (on MCP APIs)"
-echo "  - Layer 2: Security Function v1 (input validation + output sanitization)"
-echo ""
-echo "The monitoring gap:"
-echo "  - APIM diagnostic settings are NOT configured"
-echo "  - Security Function v1 uses basic logging (can't be queried)"
-echo "  - Security events are happening but NOT visible"
-echo ""
-echo "Workshop flow:"
-echo "  Section 1: Enable APIM diagnostics (gateway logs)"
-echo "  Section 2: Switch to Function v2 (structured application logs)"
-echo "  Section 3: Create dashboard (visualize)"
-echo "  Section 4: Set up alerts (actionable)"
-echo ""
-echo "Next steps:"
-echo ""
-echo "  1. Demonstrate the monitoring gap:"
-echo "     ./scripts/section1/1.1-exploit.sh"
-echo ""
-echo "  2. Enable APIM diagnostics:"
-echo "     ./scripts/section1/1.2-fix.sh"
-echo ""
-echo "  3. Validate logging is working:"
-echo "     ./scripts/section1/1.3-validate.sh"
-echo ""
+
+if [ "$DEPLOY_MODE" = "complete" ]; then
+    echo "Deploy Mode: COMPLETE"
+    echo "  All monitoring resources are deployed and configured."
+    echo ""
+    echo "What's deployed:"
+    echo "  - APIM with full I/O security (Layer 1 + Layer 2)"
+    echo "  - Sherpa MCP Server (Container App)"
+    echo "  - Trail API with PII endpoint (Container App)"
+    echo "  - Security Function v2 (structured logging - ACTIVE)"
+    echo "  - Log Analytics workspace with APIM diagnostic logs"
+    echo "  - Application Insights (shared telemetry)"
+    echo "  - Security Monitoring Workbook (dashboard)"
+    echo "  - Action Group + Alert Rules (4 security alerts)"
+    echo ""
+    echo "Next steps:"
+    echo ""
+    echo "  1. Generate sample attack data:"
+    echo "     ./scripts/section4/4.1-simulate-attack.sh"
+    echo ""
+    echo "  2. View the security dashboard in the Azure Portal:"
+    echo "     Open the Workbook under your resource group"
+    echo ""
+else
+    echo "Deploy Mode: WORKSHOP (default)"
+    echo ""
+    echo "What's deployed:"
+    echo "  - APIM with full I/O security (Layer 1 + Layer 2)"
+    echo "  - Sherpa MCP Server (Container App)"
+    echo "  - Trail API with PII endpoint (Container App)"
+    echo "  - Security Function v1 (basic logging - ACTIVE)"
+    echo "  - Security Function v2 (structured logging - deployed, not active)"
+    echo "  - Log Analytics workspace (not yet connected to APIM)"
+    echo ""
+    echo "Security layers enabled:"
+    echo "  - Layer 1: OAuth + Content Safety (on MCP APIs)"
+    echo "  - Layer 2: Security Function v1 (input validation + output sanitization)"
+    echo ""
+    echo "The monitoring gap:"
+    echo "  - APIM diagnostic settings are NOT configured"
+    echo "  - Security Function v1 uses basic logging (can't be queried)"
+    echo "  - Security events are happening but NOT visible"
+    echo ""
+    echo "Workshop flow:"
+    echo "  Section 1: Enable APIM diagnostics (gateway logs)"
+    echo "  Section 2: Switch to Function v2 (structured application logs)"
+    echo "  Section 3: Create dashboard (visualize)"
+    echo "  Section 4: Set up alerts (actionable)"
+    echo ""
+    echo "Next steps:"
+    echo ""
+    echo "  1. Demonstrate the monitoring gap:"
+    echo "     ./scripts/section1/1.1-exploit.sh"
+    echo ""
+    echo "  2. Enable APIM diagnostics:"
+    echo "     ./scripts/section1/1.2-fix.sh"
+    echo ""
+    echo "  3. Validate logging is working:"
+    echo "     ./scripts/section1/1.3-validate.sh"
+    echo ""
+fi

--- a/docs/camps/camp4-monitoring/production-deploy.md
+++ b/docs/camps/camp4-monitoring/production-deploy.md
@@ -1,0 +1,133 @@
+---
+hide:
+  - toc
+---
+
+# Production Deployment
+
+*Deploy the fully-configured stack in one command*
+
+← [Incident Response](section4-incident-response.md)
+
+---
+
+## Skip the Workshop, Deploy Everything
+
+Throughout Camp 4, you built observability step by step: enabling diagnostics, switching to structured logging, deploying a dashboard, and creating alert rules. That's great for learning — but what if you just want the end result?
+
+The **complete deployment mode** deploys the entire Camp 4 stack in a single `azd up`, including:
+
+| Component | Workshop Mode (default) | Complete Mode |
+|-----------|------------------------|---------------|
+| APIM + Diagnostic Settings | :material-check: Deployed | :material-check: Deployed |
+| Security Function v1 (basic logging) | :material-check: **Active** | :material-check: Deployed |
+| Security Function v2 (structured logging) | :material-check: Deployed | :material-check: **Active** |
+| MCP Server + Trail API | :material-check: Deployed | :material-check: Deployed |
+| Security Dashboard (Workbook) | :material-close: Manual (Section 3) | :material-check: Deployed |
+| Alert Rules + Action Group | :material-close: Manual (Section 3) | :material-check: Deployed |
+| APIM routes to v2 | :material-close: Manual (Section 2) | :material-check: Automatic |
+
+In complete mode, APIM routes directly to v2 (structured logging) and the workbook + alert rules are deployed via Bicep — no workshop scripts needed.
+
+---
+
+## Deploy
+
+### 1. Create a Fresh Environment
+
+If you already have a Camp 4 environment from the workshop, create a new one to keep things separate:
+
+```bash
+cd camps/camp4-monitoring
+
+# Create a new azd environment
+azd env new camp4-complete
+
+# Set your subscription and region
+azd env set AZURE_SUBSCRIPTION_ID <your-subscription-id>
+azd env set AZURE_LOCATION <your-region>
+```
+
+!!! tip "Finding Your Subscription ID"
+    ```bash
+    az account show --query id -o tsv
+    ```
+
+### 2. Set Complete Mode
+
+```bash
+azd env set DEPLOY_MODE complete
+```
+
+This single variable controls the full deployment:
+
+- **Bicep** conditionally deploys the workbook, action group, and alert rules
+- **Postprovision hook** routes APIM to v2 instead of v1
+
+### 3. Deploy
+
+```bash
+azd up
+```
+
+This takes ~10-15 minutes. When it finishes, you'll have the complete observability stack running.
+
+??? info "What Gets Deployed"
+    The `azd up` command runs three phases:
+
+    **Provision** (Bicep infrastructure):
+
+    - Log Analytics workspace + Application Insights
+    - Container Apps environment with MCP server and Trail API
+    - Azure Functions (v1 and v2)
+    - API Management with diagnostic settings, policies, and Prompt Shields
+    - **Security Dashboard** (Azure Workbook) with 4 panels
+    - **Action Group** for alert notifications
+    - **4 Alert Rules**: high injection rate, unusual PII volume, security errors, credential exposure
+
+    **Postprovision** (configuration):
+
+    - APIM APIs and operations configured via REST API
+    - Content Safety policy fragment applied
+    - `function-app-url` named value set to **v2** (structured logging)
+
+    **Deploy** (code):
+
+    - Security Function v1 and v2 uploaded to Azure Functions
+    - MCP server and Trail API container images pushed and deployed
+
+### 4. Run the Simulated Attack
+
+Once deployment completes, immediately run the attack simulation to generate data:
+
+```bash
+./scripts/section4/4.1-simulate-attack.sh
+```
+
+This sends multiple attack types (SQL injection, path traversal, shell injection, prompt injection) through the APIM gateway. While the logs are ingesting, you can verify the deployment.
+
+### 5. Verify in the Portal
+
+By the time you've navigated to the portal, the logs should be flowing. Open your resource group and check:
+
+- **MCP Security Dashboard** (Workbook) → Scorecards show injection and PII counts, pie chart shows blocked attacks by category
+- **Log Analytics** → Logs → Run: `AppTraces | where TimeGenerated > ago(10m) | take 10`
+- **Monitor** → Alert rules → 4 active rules (high injection rate should have fired from the simulation)
+
+!!! tip "Log Ingestion Delay"
+    Azure Log Analytics typically has a 2-5 minute ingestion delay. If the dashboard is empty, wait a couple of minutes and refresh.
+
+---
+
+## Cleanup
+
+```bash
+# Remove all Azure resources for this environment
+azd down --force --purge
+
+# Clean up Entra ID app registrations (ignore errors if already deleted)
+az ad app delete --id $(azd env get-value MCP_APP_CLIENT_ID)
+az ad app delete --id $(azd env get-value APIM_CLIENT_APP_ID)
+```
+
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Function Observability: camps/camp4-monitoring/section2-function-observability.md
       - Dashboards & Alerts: camps/camp4-monitoring/section3-dashboards-alerts.md
       - Incident Response: camps/camp4-monitoring/section4-incident-response.md
+      - Production Deployment: camps/camp4-monitoring/production-deploy.md
       - Reference: camps/camp4-monitoring/reference.md
     - The Summit: camps/summit.md
   - Resources:


### PR DESCRIPTION
Fixes dashboard and alert rule bugs discovered during testing, and adds a
complete deployment mode that skips the step-by-step workshop.

### Dashboard (workbook.bicep)
- Replace flat-line timechart with Security Summary Scorecards (4 tiles)
- Remove redundant PII and Error Rate panels (now 4 panels total)
- Fix severity extraction KQL and color thresholds

### Alert Rules (alert-rules.bicep)
- Fix timeAggregation bug: `Count` → `Total` with `metricMeasureColumn` so
  alerts actually fire based on aggregated values instead of row count

### DEPLOY_MODE=complete
- New `DEPLOY_MODE` parameter conditionally deploys workbook + alerts via Bicep
- Postprovision hook routes APIM to v2 when `DEPLOY_MODE=complete`
- New docs page: Production Deployment guide

### Other
- Add severity metadata to `mcp-content-safety.xml` policy fragment