### PR TITLE
camp4: polish all docs pages for consistency and readability

### DIFF
--- a/docs/camps/camp4-monitoring/index.md
+++ b/docs/camps/camp4-monitoring/index.md
@@ -15,7 +15,7 @@ hide:
 
 ### Welcome to Observation Peak!
 
-You've made it to Camp 4, the last skill-building camp before the Summit! Throughout your journey, you've built authentication (Camp 1), MCP gateways (Camp 2), and I/O security (Camp 3). Your MCP server is now protected by multiple layers of defense.
+You've made it to Camp 4, the last skill-building camp before the Summit! Throughout your journey, you've locked down authentication, put a gateway in front of your MCP servers, and added input validation and output sanitization. Your servers are now protected by multiple layers of defense.
 
 But here's a question: **How do you know it's working?**
 
@@ -75,33 +75,7 @@ By the end of Camp 4, every request will be logged, visualized, and alertable. H
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-<div class="grid cards" markdown>
-
-- :material-math-log:{ .lg .middle } __Structured Logging__
-
-    ---
-
-    Transform generic log messages into rich, queryable events with custom dimensions like `event_type`, `category`, and `correlation_id`.
-
-- :material-chart-line:{ .lg .middle } __Security Dashboard__
-
-    ---
-
-    Visualize attacks, PII redactions, and credential exposures in real-time with Azure Workbooks.
-
-- :material-bell-alert:{ .lg .middle } __Smart Alerting__
-
-    ---
-
-    Get notified immediately when attack rates spike or credentials are exposed.
-
-- :material-magnify:{ .lg .middle } __KQL Queries__
-
-    ---
-
-    Learn Kusto Query Language to analyze security events and create custom reports.
-
-</div>
+You'll wire up structured logging, build a security dashboard with Azure Workbooks, create alert rules that fire when attacks spike, and learn KQL to investigate incidents across services.
 
 ---
 
@@ -114,9 +88,6 @@ Before starting Camp 4, ensure you have:
 :material-check: Azure Developer CLI installed (`azd auth login`)  
 :material-check: Docker installed and running (for Container Apps deployment)  
 :material-check: Completed Camp 3: I/O Security (recommended, but not required)
-
-!!! note "Standalone Lab"
-    While Camp 4 builds on concepts from earlier camps, it's designed to work standalone. The `azd up` command will deploy everything you need, including the security function from Camp 3.
 
 :material-arrow-right: [Full prerequisites guide](../../prerequisites.md) with installation instructions for all tools.
 
@@ -132,76 +103,14 @@ cd camps/camp4-monitoring
 azd up
 ```
 
-This deploys:
+This deploys an APIM gateway, security functions (v1 with basic logging, v2 with structured logging), a Log Analytics workspace, Application Insights, and the MCP server and Trail API on Container Apps.
 
-- **Security Function v1** - Basic logging (the "hidden" state) - **ACTIVE**
-- **Security Function v2** - Structured logging with Azure Monitor - deployed but not active
-- **Log Analytics Workspace** - Central log storage for querying
-- **Application Insights** - Telemetry collection (shared by all services)
-- **APIM Gateway** - API Management with diagnostic settings pre-configured
-- **Container Apps** - MCP server and Trail API backends with OpenTelemetry
+!!! tip "Just want the full solution?"
+    Skip the workshop and deploy everything at once — dashboards, alerts, and structured logging included. See [Production Deployment](production-deploy.md).
 
-!!! note "Initial State"
-    The deployment creates a ready-to-use observability foundation:
-    
-    - APIM diagnostic settings are configured (ApiManagementGatewayLogs flow immediately)
-    - APIM's `function-app-url` named value points to v1 (basic logging)
-    - v1 uses `logging.warning()` which writes to console, not Application Insights
-    
-    Both function versions are pre-deployed. The workshop scripts switch between them by updating APIM's named value—no redeployment needed!
+Once deployment completes, you're ready to start the workshop. Camp 4 follows the **hidden → visible → actionable** pattern — you'll explore what's already logging, make hidden events visible, then turn that visibility into dashboards and alerts.
 
-Once deployment completes, you're ready to start the workshop.
-
----
-
-## Workshop Roadmap
-
-Camp 4 follows the **hidden → visible → actionable** pattern:
-
-<div class="grid cards" markdown>
-
-- :material-eye:{ .lg .middle } __APIM: Pre-Configured__
-
-    ---
-
-    APIM diagnostic settings are deployed via Bicep. Gateway logs flow to Log Analytics automatically. Section 1 explores and validates this configuration.
-
-- :material-eye-off:{ .lg .middle } __Functions: Hidden__
-
-    ---
-
-    Security function v1 uses basic `logging.warning()`. Events occur but aren't queryable in Log Analytics. Section 2 fixes this.
-
-- :material-bell-ring:{ .lg .middle } __Actionable__
-
-    ---
-
-    Create dashboards for monitoring and alerts that notify you when something needs attention. Turn visibility into automated response.
-
-</div>
-
-| Section | Focus | Page |
-|---------|-------|------|
-| **Gateway Logging** | Explore pre-configured diagnostics and validate logs flow | [Start →](section1-apim-logging.md) |
-| **Function Observability** | Switch from v1 (basic) to v2 (structured logging) | [Start →](section2-function-observability.md) |
-| **Dashboards & Alerts** | Make security actionable | [Start →](section3-dashboards-alerts.md) |
-| **Incident Response** | Test the complete system | [Start →](section4-incident-response.md) |
-
-Additional resources: [KQL Primer, Architecture Deep Dive, Troubleshooting →](reference.md)
-
----
-
-## What You'll Learn
-
-!!! tip "Learning Objectives"
-    - **Enable** APIM diagnostic settings for gateway and AI gateway logs
-    - **Implement** structured security logging in Azure Functions with correlation IDs
-    - **Query** logs using KQL for security investigations with full log correlation
-    - **Build** security monitoring dashboards using Azure Workbooks
-    - **Create** alert rules for attack pattern detection
-    - **Perform** incident response exercises with cross-service log tracing
-
-Ready? Let's start by exploring what APIM is already logging.
+Ready? Let's start by exploring what API Management is already logging.
 
 [Start: Gateway Logging →](section1-apim-logging.md){ .md-button .md-button--primary }
 

--- a/docs/camps/camp4-monitoring/production-deploy.md
+++ b/docs/camps/camp4-monitoring/production-deploy.md
@@ -72,7 +72,7 @@ azd up
 
 This takes ~10-15 minutes. When it finishes, you'll have the complete observability stack running.
 
-??? info "What Gets Deployed"
+???+ info "What Gets Deployed"
     The `azd up` command runs three phases:
 
     **Provision** (Bicep infrastructure):

--- a/docs/camps/camp4-monitoring/reference.md
+++ b/docs/camps/camp4-monitoring/reference.md
@@ -13,12 +13,6 @@ hide:
 
 ## Understanding Observability
 
-### Logging vs. Observability
-
-You might be thinking: *"I already have logs. My application writes to console. Isn't that enough?"*
-
-Not quite. There's a crucial difference:
-
 | Aspect | Basic Logging | Observability |
 |--------|---------------|---------------|
 | **What it captures** | Text messages | Structured events with dimensions |
@@ -27,126 +21,29 @@ Not quite. There's a crucial difference:
 | **Visualization** | Read log files | Dashboards, charts, trends |
 | **Alerting** | Custom scripts | Built-in threshold monitoring |
 
-!!! example "A Tale of Two Approaches"
-    **Basic logging:** `WARNING: Injection blocked: sql_injection`
-    
-    - Where did it come from? 🤷
-    - What tool was targeted? 🤷
-    - How many happened today? 🤷 (time to write a grep script...)
-    
-    **Structured observability:**
-    ```json
-    {
-      "event_type": "INJECTION_BLOCKED",
-      "injection_type": "sql_injection",
-      "tool_name": "search-trails",
-      "correlation_id": "abc-123-xyz",
-      "caller_ip": "203.0.113.42",
-      "timestamp": "2024-01-15T14:30:00Z"
-    }
-    ```
-    
-    Now you can instantly answer: *"Show me all SQL injections targeting the search-trails tool in the last hour, grouped by source IP."*
-
-### The Three Pillars of Observability
-
-Modern observability rests on three pillars:
-
-<div class="grid cards" markdown>
-
-- :material-format-list-bulleted:{ .lg .middle } __Logs__
-
-    ---
-
-    Discrete events that tell you *what happened*. "User called tool X" or "Injection blocked."
-
-- :material-gauge:{ .lg .middle } __Metrics__
-
-    ---
-
-    Numerical measurements over time. Requests per second, error rates, latency percentiles.
-
-- :material-map-marker-path:{ .lg .middle } __Traces__
-
-    ---
-
-    The path a request takes through your system. Essential for understanding "why was this slow?"
-
-</div>
-
-In this workshop, we focus primarily on **logs** (structured events) while touching on metrics and traces through correlation IDs.
+The difference matters: `WARNING: Injection blocked: sql_injection` tells you something happened. A structured event with `event_type`, `injection_type`, `tool_name`, `correlation_id`, and `caller_ip` tells you *everything*, and lets you query, aggregate, and alert on it automatically.
 
 ---
 
 ## Meet Azure Monitor
 
-### The Azure Monitor Family
+Camp 4 uses four Azure Monitor components:
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         Azure Monitor                               │
-│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────────┐  │
-│  │  Log Analytics  │  │   Application   │  │    Azure Monitor    │  │
-│  │    Workspace    │  │    Insights     │  │      Alerts         │  │
-│  │                 │  │                 │  │                     │  │
-│  │  • Store logs   │  │  • Auto-collect │  │  • Threshold rules  │  │
-│  │  • KQL queries  │  │    from apps    │  │  • Email/webhook    │  │
-│  │  • Retention    │  │  • APM features │  │  • Action groups    │  │
-│  └────────┬────────┘  └────────┬────────┘  └──────────┬──────────┘  │
-│           │                    │                      │             │
-│           └──────────────┬─────┴──────────────────────┘             │
-│                          │                                          │
-│              ┌───────────┴───────────┐                              │
-│              │    Azure Workbooks    │                              │
-│              │   (Visualizations)    │                              │
-│              └───────────────────────┘                              │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-**Log Analytics Workspace** is your central log repository. Think of it as a powerful database optimized for time-series log data. You query it using KQL (Kusto Query Language).
-
-**Application Insights** is specifically designed for application monitoring. When you add it to your Azure Function, it automatically captures requests, exceptions, and traces, plus any custom events you log.
-
-**Azure Workbooks** are interactive reports that combine text, KQL queries, and visualizations. They're perfect for security dashboards.
-
-**Azure Monitor Alerts** let you define rules that trigger when conditions are met. "If more than 10 injections in 5 minutes, email the security team."
+| Component | Role |
+|-----------|------|
+| **Log Analytics Workspace** | Central log repository — you query it with KQL |
+| **Application Insights** | App monitoring — auto-captures requests, exceptions, and traces from your Functions |
+| **Azure Workbooks** | Interactive dashboards combining text, KQL queries, and visualizations |
+| **Azure Monitor Alerts** | Rules that trigger notifications when conditions are met |
 
 ### How Logs Flow
 
-Understanding the data flow helps when troubleshooting. Camp 4 has a **two-layer security architecture**:
+Camp 4 has a **two-layer security architecture**. Both layers stream telemetry to the same Log Analytics workspace:
 
-```
-Your MCP Request
-       │
-       ▼
-┌──────────────────────────────────────────────────────────────────┐
-│                    LAYER 1: APIM + Prompt Shields                │
-│  ┌──────────────┐     Diagnostic Settings     ┌───────────────┐  │
-│  │     APIM     │ ──────────────────────────► │ Log Analytics │  │
-│  │   Gateway    │     GatewayLogs             │   Workspace   │  │
-│  │              │     GatewayLlmLogs          │               │  │
-│  │   + Prompt   │     WebSocketConnectionLogs │ ApiMgmt...    │  │
-│  │    Shields   │                             │ tables        │  │
-│  │              │     <trace> policy ────────►│               │  │
-│  │              │     (INJECTION_BLOCKED)     │ AppTraces     │  │
-│  └──────┬───────┘                             └───────────────┘  │
-│         │                                                        │
-│     Blocks: Prompt injection                                     │
-└─────────┼────────────────────────────────────────────────────────┘
-          │ If not blocked at Layer 1
-          ▼
-┌──────────────────────────────────────────────────────────────────┐
-│                    LAYER 2: Security Function                    │
-│  ┌──────────────┐     App Insights SDK        ┌───────────────┐  │
-│  │   Security   │ ──────────────────────────► │  Application  │  │
-│  │   Function   │     Custom events +         │   Insights    │  │
-│  │              │     auto-instrumentation    │               │  │
-│  │              │                             │ AppTraces     │  │
-│  └──────────────┘                             └───────────────┘  │
-│                                                                  │
-│     Blocks: SQL injection, Path traversal, Shell injection       │
-└──────────────────────────────────────────────────────────────────┘
-```
+| Layer | Source | Log Destination | What It Catches |
+|-------|--------|----------------|----------------|
+| **Layer 1** | APIM + Prompt Shields | `ApiManagementGatewayLogs` + `AppTraces` (via `<trace>` policy) | Prompt injection (AI-based) |
+| **Layer 2** | Security Function | `AppTraces` (via App Insights SDK) | SQL injection, path traversal, shell injection, PII, credentials |
 
 !!! info "Two Log Formats for Security Events"
     - **Layer 1 (APIM)**: Logs to `Properties.event_type` directly
@@ -159,30 +56,7 @@ Your MCP Request
 
 ### Unified Telemetry
 
-Camp 4 uses a **single shared Application Insights** instance for all services. This enables:
-
-- **Single pane of glass**: Query logs from APIM, MCP Server, Functions, and Trail API in one place
-- **KQL across services**: Write queries that join telemetry from multiple services
-- **Transaction Search**: Find specific requests by correlation ID and trace them across all services
-- **Consistent alerting**: Create alerts that span the entire system
-
-```
-┌───────────────────────────────────────────────────────────────────────────┐
-│                         Shared Application Insights                       │
-│                                                                           │
-│    ┌─────────┐     ┌─────────────────┐     ┌──────────────────┐           │
-│    │  APIM   │     │  Sherpa MCP     │     │  Trail API       │           │
-│    │ Gateway │     │  Server         │     │  (REST)          │           │
-│    └─────────┘     └─────────────────┘     └──────────────────┘           │
-│                                                                           │
-│                    ┌────────────────┐                                     │
-│                    │  Security      │                                     │
-│                    │  Function      │                                     │
-│                    └────────────────┘                                     │
-│                                                                           │
-│   All services report to the same App Insights for unified queries        │
-└───────────────────────────────────────────────────────────────────────────┘
-```
+All four services (APIM, security function v1/v2, MCP server, trail API) report to a **single shared Application Insights** instance. This gives you a single pane of glass — KQL queries can join telemetry across services, and alerts span the entire system.
 
 !!! tip "Correlation IDs"
     Use the `x-correlation-id` header (based on APIM's RequestId) to trace requests across services in your KQL queries.
@@ -326,6 +200,16 @@ Think of custom dimensions as adding columns to your log database that you can f
 This section is your **cheat sheet**—a collection of queries you'll use regularly for security monitoring.
 
 Each query is designed to answer a specific question. Copy them into Log Analytics and modify as needed.
+
+!!! info "Common Parse Pattern"
+    Most queries below use the same boilerplate to handle both Layer 1 (APIM) and Layer 2 (Function) log formats:
+    ```kusto
+    | extend Props = parse_json(Properties)
+    | extend CustomDims = parse_json(replace_string(replace_string(
+        tostring(Props.custom_dimensions), "'", "\""), "None", "null"))
+    | extend EventType = coalesce(tostring(Props.event_type), tostring(CustomDims.event_type))
+    ```
+    See [Working with Custom Dimensions](#working-with-custom-dimensions) for why this is necessary.
 
 !!! tip "Running KQL Queries"
     To run these queries:
@@ -638,29 +522,12 @@ Layer 2 logs are at `Properties.custom_dimensions.event_type`.
 
 ### Log Table Relationships
 
-Here's how the tables connect via CorrelationId, and the two different log formats for security events:
+The tables connect via `CorrelationId`. The key difference between Layer 1 and Layer 2 logs is where properties are stored:
 
-```
-ApiManagementGatewayLogs              AppTraces (Layer 1 - APIM)
-┌────────────────────────┐            ┌──────────────────────────────────┐
-│ CorrelationId: abc-123 │────────────│ Properties.event_type:           │
-│ CallerIpAddress: ...   │            │   INJECTION_BLOCKED              │
-│ ResponseCode: 403      │            │ Properties.category:             │
-│ ApiId: sherpa-mcp      │            │   prompt_injection               │
-│ Method: POST           │            │ Properties.correlation_id:       │
-└────────────────────────┘            │   abc-123                        │
-                                      └──────────────────────────────────┘
+- **Layer 1 (APIM)**: Properties at root level — `Properties.event_type`
+- **Layer 2 (Function)**: Properties nested in `custom_dimensions` as a Python dict string — requires `parse_json(replace_string(...))`
 
-                                      AppTraces (Layer 2 - Function)
-                                      ┌──────────────────────────────────┐
-                                      │ Properties.custom_dimensions:    │
-                                      │   {'event_type': 'INJECTION_..', │
-                                      │    'category': 'sql_injection',  │
-                                      │    'correlation_id': 'def-456'}  │
-                                      └──────────────────────────────────┘
-```
-
-Notice Layer 1 logs have properties at the root level, while Layer 2 logs have them nested in `custom_dimensions` as a Python dict string. This is why queries need `coalesce()` to handle both formats.
+Dashboard queries use `coalesce()` to handle both formats transparently.
 
 ### Outbound Policy Considerations
 
@@ -698,7 +565,7 @@ The sherpa-mcp-server returns **single JSON responses** for its simple tools. Th
 
 Things don't always work the first time. Here are the most common issues and how to fix them.
 
-??? question "My KQL queries return no results"
+???+ question "My KQL queries return no results"
 
     **Don't panic!** This is the #1 issue people hit. Check these things in order:
 
@@ -723,7 +590,7 @@ Things don't always work the first time. Here are the most common issues and how
 
     5. **Generate some events!** Run the exploit scripts to create log entries, then wait a few minutes.
 
-??? question "The dashboard shows 'No data'"
+???+ question "The dashboard shows 'No data'"
 
     **Workbooks need data to display.** If panels are empty:
 
@@ -738,7 +605,7 @@ Things don't always work the first time. Here are the most common issues and how
 
     4. **Check the workspace connection** - Make sure the workbook is querying the right Log Analytics workspace
 
-??? question "Alerts aren't firing even though I see events"
+???+ question "Alerts aren't firing even though I see events"
 
     **Alerts run on a schedule, not in real-time:**
 
@@ -752,7 +619,7 @@ Things don't always work the first time. Here are the most common issues and how
 
     4. **Check action group**: Even if the alert fires, notifications need a properly configured action group with valid email/webhook.
 
-??? question "Properties.event_type returns nothing but I see the data"
+???+ question "Properties.event_type returns nothing but I see the data"
 
     **This depends on which layer emitted the log:**
     
@@ -798,7 +665,7 @@ Things don't always work the first time. Here are the most common issues and how
     {"custom_dimensions": "{'event_type': 'INJECTION_BLOCKED', ...}"}
     ```
 
-??? question "I'm seeing 'Request rate is large' errors"
+???+ question "I'm seeing 'Request rate is large' errors"
 
     **You might be hitting rate limits.** This happens if you:
     

--- a/docs/camps/camp4-monitoring/section1-apim-logging.md
+++ b/docs/camps/camp4-monitoring/section1-apim-logging.md
@@ -11,72 +11,17 @@ hide:
 
 ---
 
-APIM processes all your MCP traffic, and in this workshop, diagnostic settings are pre-configured via Bicep. This section explores what's been configured and validates that logs are flowing.
+Every MCP reques, legitimate or malicious, passes through APIM. By default, APIM routes traffic but records nothing. In this workshop, the Bicep infrastructure pre-configures **diagnostic settings** that stream two log categories (`GatewayLogs` and `GatewayLlmLogs`) to your Log Analytics workspace, so you can query traffic immediately after `azd up`.
 
-## The Logging Gap: Before & After
-
-Understanding diagnostic settings helps when configuring other Azure resources. Here's what APIM looks like without diagnostic settings vs with them:
-
-```
-WITHOUT: No Diagnostic Settings                WITH: Diagnostics Enabled (Our Setup)
-═══════════════════════════════════════        ═══════════════════════════════════════
-
-   MCP Client                                     MCP Client
-       │                                              │
-       ▼                                              ▼
-┌──────────────┐                                ┌──────────────┐
-│    APIM      │                                │    APIM      │───────────────────┐
-│   Gateway    │                                │   Gateway    │                   │
-│              │                                │              │   Diagnostic      │
-│  • Routes ✓  │                                │  • Routes ✓  │   Settings        │
-│  • Policies ✓│                                │  • Policies ✓│                   │
-│  • Logs?     │                                │  • Logs ✓    │                   ▼
-└──────┬───────┘                                └──────┬───────┘        ┌─────────────────┐
-       │                                               │                │  Log Analytics  │
-       ▼                                               ▼                │                 │
-┌─────────────┐                                ┌─────────────┐          │ • GatewayLogs   │
-│   Backend   │                                │   Backend   │          │ • GatewayLlmLogs│
-│   Services  │                                │   Services  │          └─────────────────┘
-└─────────────┘                                └─────────────┘                │
-                                                                              ▼
-Traffic works fine,                            Traffic works AND           KQL Queries
-but NO VISIBILITY                              you can QUERY everything    Dashboards
-                                                                           Alerts
-```
-
-## Why Gateway Logging Matters
-
-Azure API Management sits at the front door of your MCP infrastructure. Every request, legitimate or malicious, passes through it. In this workshop, **APIM diagnostic settings are pre-configured via Bicep**, so you can immediately query logs once `azd up` completes.
-
-!!! success "Pre-Configured for Learning"
-    Unlike a default APIM deployment where you'd have no visibility, this workshop configures diagnostic settings automatically during infrastructure deployment. This means:
-    
-    - :material-check: Gateway logs flow to Log Analytics immediately
-    - :material-check: You can start querying traffic right away
-    - :material-check: No manual configuration required
-
-With diagnostic settings enabled, you have full visibility into:
-
-- Who called your APIs (IP addresses)  
-- What MCP tools were invoked  
-- How long requests took  
-- Which requests failed and why
-
-!!! example "The Security Guard Analogy"
-    It's like having a security guard who checks IDs **and** writes down every entry in a log book. The guard does their job, and there's a complete record anyone can review later.
-
-## Understanding Diagnostic Settings
-
-**Diagnostic Settings** are Azure's way of routing telemetry from a resource to a destination. For APIM, you configure:
-
-- **Source**: Which log categories to capture (GatewayLogs, GatewayLlmLogs)
-- **Destination**: Where to send them (Log Analytics workspace)
-
-In this workshop, the Bicep infrastructure configures these automatically. Once deployed, APIM streams logs to your workspace without any manual steps.
+| Without Diagnostic Settings | With Diagnostic Settings (this workshop) |
+|-----------------------------|------------------------------------------|
+| Traffic routes normally | Traffic routes normally |
+| No record of who called, what failed, or how long it took | Every request logged with caller IP, timing, response code, correlation ID |
+| Incidents are invisible | Queryable via KQL → dashboards → alerts |
 
 ## 1.1 Explore APIM Gateway Logging
 
-??? abstract "Send Traffic and See Logs Flow"
+???+ abstract "Send Traffic and See Logs Flow"
 
     Run the script to send traffic through APIM and verify logging:
 
@@ -105,7 +50,7 @@ In this workshop, the Bicep infrastructure configures these automatically. Once 
 
 ## 1.2 Verify Diagnostic Configuration
 
-??? success "Understand What's Configured"
+???+ success "Understand What's Configured"
 
     Examine the diagnostic settings:
 
@@ -113,42 +58,17 @@ In this workshop, the Bicep infrastructure configures these automatically. Once 
     ./scripts/section1/1.2-verify.sh
     ```
 
-    **What this does:**
-
-    Shows you the diagnostic settings deployed via Bicep, including enabled log categories and destination.
-
-    **ApiManagementGatewayLogs (HTTP level):**
-
-    | Field | Description |
-    |-------|-------------|
-    | `CallerIpAddress` | Client IP (for investigations) |
-    | `ResponseCode` | HTTP response code |
-    | `CorrelationId` | For cross-service tracing |
-    | `Url`, `Method` | Request path and HTTP method |
-    | `ApiId` | API identifier for filtering |
-
-    **ApiManagementGatewayLlmLog (AI/LLM gateway):**
-
-    | Field | Description |
-    |-------|-------------|
-    | `PromptTokens` | Input token count |
-    | `CompletionTokens` | Output token count |
-    | `ModelName` | LLM model used |
-    | `CorrelationId` | For cross-service tracing |
+    Shows the diagnostic settings deployed via Bicep, which log categories are enabled, and where they're sent. See the **Key Log Tables** below for the fields available in each table.
 
     !!! tip "Verify in Azure Portal"
-        You can also view diagnostic settings by navigating to your APIM resource:
-        
         **APIM** → **Monitoring** → **Diagnostic settings** → **mcp-security-logs**
-        
-        You should see `GatewayLogs` and `GatewayLlmLogs` enabled, pointing to your Log Analytics workspace.
 
 ## 1.3 Validate Logs Appear
 
 !!! warning "Wait for Log Ingestion"
     For new deployments, logs need 2-5 minutes to appear in Log Analytics. If you run this immediately after `azd up`, you may see "No HTTP logs found yet." Wait a few minutes and try again.
 
-??? success "Query APIM Logs"
+???+ success "Query APIM Logs"
 
     Verify logs are flowing:
 
@@ -184,8 +104,7 @@ This section uses these Azure Monitor log tables:
 | **ApiManagementGatewayLogs** | GatewayLogs | `CallerIpAddress`, `ResponseCode`, `CorrelationId`, `Url`, `Method`, `ApiId` |
 | **ApiManagementGatewayLlmLog** | GatewayLlmLogs | `PromptTokens`, `CompletionTokens`, `ModelName`, `CorrelationId` |
 
-!!! info "Correlation IDs"
-    The **CorrelationId** field appears across all log tables and is essential for incident response. It allows you to trace a single request from APIM through the security function and back, correlating HTTP logs and application traces.
+The `CorrelationId` field appears in both tables — you'll use it in Section 4 to trace a single request across APIM and the security function.
 
 ---
 

--- a/docs/camps/camp4-monitoring/section2-function-observability.md
+++ b/docs/camps/camp4-monitoring/section2-function-observability.md
@@ -15,31 +15,7 @@ APIM logs show HTTP traffic, but the security function's internal operations (wh
 
 ## Two-Layer Blocking Architecture
 
-Attacks are blocked at **two different layers**, and understanding this is key to writing correct queries:
-
-```
-                          MCP Request
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                    LAYER 1: APIM Policy                             │
-│                                                                     │
-│    Prompt Shields (Azure Content Safety)                            │
-│    • Blocks prompt injection attacks                                │
-│    • Structured logging via <trace> policy                          │
-│    • Logs directly to AppTraces: Properties.event_type              │
-└──────────────────────────────┬──────────────────────────────────────┘
-                               │ (if not blocked)
-                               ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                    LAYER 2: Security Function                       │
-│                                                                     │
-│    Regex-based pattern detection                                    │
-│    • Blocks SQL injection, path traversal, shell injection          │
-│    • Structured logging via OpenTelemetry                           │
-│    • Logs to AppTraces: Properties.custom_dimensions.event_type     │
-└─────────────────────────────────────────────────────────────────────┘
-```
+Attacks are blocked at two layers, and each logs to a different property path. KQL queries need to check **both** locations to capture all attack types:
 
 | Attack Type | Blocked By | Log Location |
 |-------------|-----------|--------------|
@@ -47,8 +23,6 @@ Attacks are blocked at **two different layers**, and understanding this is key t
 | **SQL injection** | Layer 2 (Security Function) | `Properties.custom_dimensions.event_type` |
 | **Path traversal** | Layer 2 (Security Function) | `Properties.custom_dimensions.event_type` |
 | **Shell injection** | Layer 2 (Security Function) | `Properties.custom_dimensions.event_type` |
-
-This two-layer design means KQL queries need to check **both** property locations to capture all attack types. The unified query pattern using `coalesce()` handles this automatically.
 
 ## The Problem: Basic Logging Is Invisible
 
@@ -63,7 +37,7 @@ This produces a log line like:
 2024-01-15 14:30:00 WARNING Injection blocked: sql_injection
 ```
 
-Simple, readable, and utterly useless for security analysis at scale:
+Simple and readable, but not useful for security analysis at scale:
 
 - **You can't query it** — Want to count SQL injections vs. shell injections? You'd need fragile regex parsing.
 - **You can't correlate it** — Which APIM request triggered this log? No correlation ID to link them.
@@ -73,7 +47,7 @@ The solution is **structured logging**: emitting events as key-value pairs (dime
 
 ## 2.1 See Basic Logging Limitations
 
-??? abstract "Experience Unstructured Logs"
+???+ abstract "Experience Unstructured Logs"
 
     Run the script to trigger security events:
 
@@ -94,16 +68,16 @@ The solution is **structured logging**: emitting events as key-value pairs (dime
 
 ## 2.2 Deploy Structured Logging
 
-??? success "Switch to v2 with Custom Dimensions"
+???+ success "Switch to v2 with Custom Dimensions"
 
-    Switch APIM to use the pre-deployed v2 function:
+    Switch APIM to use the pre-deployed v2 function and send test attacks:
 
     ```bash
     ./scripts/section2/2.2-fix.sh
     ```
 
     !!! tip "No Redeployment Required!"
-        Both function versions were deployed during initial `azd up`. This script simply updates APIM's named value `function-app-url` to point to v2. The switch is instant!
+        Both function versions were deployed during initial `azd up`. This script updates APIM's named value `function-app-url` to point to v2, then sends a few test attacks (SQL injection, path traversal, shell injection) to generate structured log entries for the next step.
 
     **What changes:**
 
@@ -147,21 +121,18 @@ The solution is **structured logging**: emitting events as key-value pairs (dime
 
 ## 2.3 Validate Structured Logs
 
-!!! warning "Wait for Log Ingestion"
-    The test attacks from 2.2-fix.sh need 2-5 minutes to appear in Log Analytics. If you run this immediately after 2.2, you may see "No structured logs found yet." Wait a few minutes and try again.
+???+ success "Query Security Events"
 
-??? success "Query Security Events"
+    !!! warning "Wait for Log Ingestion"
+        The test attacks from step 2.2 need 2-5 minutes to appear in Log Analytics. If you see "No structured logs found yet," wait a few minutes and try again.
 
-    !!! note "Layer 2 Queries"
-        These queries target Layer 2 (Security Function) logs specifically. For unified queries that handle both Layer 1 (APIM/Prompt Shields) and Layer 2 logs, see the [KQL Query Reference](reference.md#kql-query-reference).
-
-    Verify structured events appear:
+    Run the validation script:
 
     ```bash
     ./scripts/section2/2.3-validate.sh
     ```
 
-    **Count attacks by injection type:**
+    **Try it yourself** — open Log Analytics in the Azure portal and run this query to count attacks by type:
 
     ```kusto
     AppTraces
@@ -175,85 +146,10 @@ The solution is **structured logging**: emitting events as key-value pairs (dime
     | order by Count desc
     ```
 
-    **Recent security events with details:**
+    The `parse_json(replace_string(...))` pattern normalizes Python's single-quoted JSON into valid JSON for KQL. You'll see this pattern throughout the workshop.
 
-    ```kusto
-    AppTraces
-    | where Properties has "event_type"
-    | extend CustomDims = parse_json(replace_string(replace_string(
-        tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
-    | extend EventType = tostring(CustomDims.event_type),
-             InjectionType = tostring(CustomDims.injection_type),
-             ToolName = tostring(CustomDims.tool_name),
-             CorrelationId = tostring(CustomDims.correlation_id)
-    | where EventType == "INJECTION_BLOCKED"
-    | project TimeGenerated, EventType, InjectionType, ToolName, CorrelationId
-    | order by TimeGenerated desc
-    | limit 20
-    ```
-
-    **Most targeted tools:**
-
-    ```kusto
-    AppTraces
-    | where Properties has "event_type"
-    | extend CustomDims = parse_json(replace_string(replace_string(
-        tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
-    | where tostring(CustomDims.event_type) == "INJECTION_BLOCKED"
-    | extend ToolName = tostring(CustomDims.tool_name)
-    | where isnotempty(ToolName)
-    | summarize AttackCount=count() by ToolName
-    | order by AttackCount desc
-    ```
-
-    **End-to-end correlation (auto-finds latest correlation ID):**
-
-    This query finds the most recent blocked attack and traces it across both APIM and Function logs:
-
-    ```kusto
-    // Get the most recent correlation ID from a blocked attack
-    let timeRange = ago(24h);  // Adjust as needed
-    let recentAttack = AppTraces
-    | where TimeGenerated > timeRange
-    | where Properties has "event_type"
-    | extend CustomDims = parse_json(replace_string(replace_string(
-        tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
-    | where tostring(CustomDims.event_type) == "INJECTION_BLOCKED"
-    | extend CorrelationId = tostring(CustomDims.correlation_id)
-    | top 1 by TimeGenerated desc
-    | project CorrelationId;
-    // Now trace that request across APIM and Function
-    let correlationId = toscalar(recentAttack);
-    union
-        (ApiManagementGatewayLogs 
-         | where TimeGenerated > timeRange
-         | where CorrelationId == correlationId
-         | project TimeGenerated, Source="APIM", CorrelationId,
-                   Details=strcat("HTTP ", ResponseCode, " from ", CallerIpAddress)),
-        (AppTraces 
-         | where TimeGenerated > timeRange
-         | where Properties has "correlation_id"
-         | extend CustomDims = parse_json(replace_string(replace_string(
-             tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
-         | where tostring(CustomDims.correlation_id) == correlationId
-         | project TimeGenerated, Source="Function", CorrelationId=tostring(CustomDims.correlation_id),
-                   Details=strcat(tostring(CustomDims.event_type), ": ", tostring(CustomDims.injection_type)))
-    | order by TimeGenerated asc
-    ```
-
-    **Manual correlation (paste your own ID):**
-
-    ```kusto
-    let correlationId = "YOUR-CORRELATION-ID";
-    union
-        (ApiManagementGatewayLogs | where CorrelationId == correlationId),
-        (AppTraces 
-         | where Properties has "correlation_id"
-         | extend CustomDims = parse_json(replace_string(replace_string(
-             tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
-         | where tostring(CustomDims.correlation_id) == correlationId)
-    | order by TimeGenerated
-    ```
+    !!! note "More KQL Queries"
+        The [KQL Query Reference](reference.md#kql-query-reference) has additional queries including recent events with details, most targeted tools, end-to-end correlation tracing, and unified queries that span both Layer 1 and Layer 2 logs.
 
 ---
 

--- a/docs/camps/camp4-monitoring/section3-dashboards-alerts.md
+++ b/docs/camps/camp4-monitoring/section3-dashboards-alerts.md
@@ -11,61 +11,11 @@ hide:
 
 ---
 
-Visibility is great, but you can't watch logs 24/7. This section makes security *actionable* with dashboards and alerts.
-
-## From Visible to Actionable
-
-At this point, you've achieved visibility:
-
-:material-check: APIM logs flow to Log Analytics  
-:material-check: Security function emits structured events  
-:material-check: You can query anything with KQL
-
-But there's a problem: **nobody has time to run KQL queries all day**.
-
-The final step in the "hidden → visible → actionable" journey is making security events *surface themselves*:
-
-- **Dashboards** give you at-a-glance status without running queries
-- **Alerts** notify you when something needs attention, even at 3 AM
-
-## Azure Workbooks: Interactive Dashboards
-
-**Azure Workbooks** are interactive reports built on top of Log Analytics. They combine:
-
-- **Text** - Explanations and context
-- **KQL Queries** - Live data from your logs
-- **Visualizations** - Charts, graphs, grids
-- **Parameters** - Interactive filters (time range, environment, etc.)
-
-Unlike static dashboards, Workbooks query live data every time you view them. No ETL pipelines, no data staleness—just direct queries against your logs.
-
-!!! tip "Workbook vs. Dashboard"
-    Azure has both **Workbooks** and **Dashboards**. What's the difference?
-    
-    - **Workbooks**: Rich, document-like reports with interactivity. Best for analysis.
-    - **Dashboards**: Pinned tiles from various sources. Best for at-a-glance monitoring.
-    
-    For security monitoring, Workbooks are usually the better choice because you need the analytical depth.
-
-## Azure Monitor Alerts: Automated Notification
-
-Alerts watch your logs and take action when conditions are met. They have three components:
-
-1. **Condition**: A KQL query that returns results when something's wrong
-2. **Action Group**: Who to notify and how (email, SMS, webhook, Logic App)
-3. **Severity**: How urgent is this? (0-4, where 0 is critical)
-
-For example, our "High Attack Volume" alert:
-
-- **Condition**: More than 10 `INJECTION_BLOCKED` events in 5 minutes
-- **Action**: Email the security team
-- **Severity**: 2 (Warning)
-
-Alerts run on a schedule (every 5 minutes by default) and fire when the query returns results.
+You have structured logs flowing and you can query them with KQL. But nobody has time to run queries all day. This is the final step in the **hidden → visible → actionable** journey: dashboards for at-a-glance status, and alerts that notify you at 3 AM.
 
 ## 3.1 Deploy the Dashboard
 
-??? abstract "Create Security Workbook"
+???+ abstract "Create Security Workbook"
 
     Deploy the Azure Monitor Workbook:
 
@@ -85,70 +35,25 @@ Alerts run on a schedule (every 5 minutes by default) and fire when the query re
 
     **Dashboard panels:**
 
-    | Panel | Shows |
-    |-------|-------|
-    | Request Volume | MCP traffic over 24h |
-    | Attacks by Type | Pie chart of injection categories |
-    | Top Targeted Tools | Which MCP tools attackers probe |
-    | Error Sources | IPs generating errors |
-    | Recent Events | Live feed of security activity |
+    | Panel | Type | Shows |
+    |-------|------|-------|
+    | MCP Request Volume | Area chart | Traffic over 24h |
+    | Attacks by Injection Type | Pie chart | Breakdown of blocked attack categories |
+    | Top Targeted Tools | Bar chart | Which MCP tools attackers probe most |
+    | Top Error Sources | Table | IPs generating errors |
+    | Recent Security Events | Table | Live feed of security activity |
+
+    !!! info "Workshop vs Production Dashboard"
+        This script deploys a workshop-friendly dashboard focused on exploration. The [Production Deployment](production-deploy.md) deploys an optimized version with security summary scorecards, severity distribution, and alert-ready panels. The production dashboard is defined in Bicep and deployed automatically with `DEPLOY_MODE=complete`.
+
+    !!! info "Why Workbooks?"
+        Azure has both **Workbooks** and **Dashboards**. Workbooks are interactive, document-like reports that query live data — no ETL pipelines, no staleness. For security monitoring, they're the better choice because you need analytical depth, not just pinned tiles.
 
 ## 3.2 Create Alert Rules
 
-Dashboards are great when you're looking at them. But security incidents don't wait for business hours. Alert rules watch your logs continuously and notify you when something needs attention.
+Dashboards are great when you're looking at them. Alerts watch your logs continuously and notify you when something needs attention.
 
-### Understanding Action Groups
-
-Before creating alerts, you need to understand **Action Groups**, which are Azure's way of defining *who* gets notified and *how*.
-
-Think of an Action Group as your incident response contact list:
-
-```
-Action Group: "mcp-security-alerts"
-├── Email: security-team@company.com
-├── SMS: +1-867-5309 (on-call engineer)
-├── Webhook: https://notify.company.com/alerts
-└── Azure Function: auto-remediation-function
-```
-
-When an alert fires, it triggers everyone in the Action Group simultaneously.
-
-!!! tip "Start Simple"
-    For this workshop, we'll create an Action Group with just email notifications (or none at all). In production, you'd add SMS for critical alerts, webhooks for Slack/Teams, or even Azure Functions for automated remediation.
-
-### Anatomy of an Alert Rule
-
-An alert rule has three parts:
-
-| Component | What It Does | Example |
-|-----------|--------------|---------|
-| **Condition** | KQL query that returns results when something's wrong | "More than 10 injection attacks in 5 minutes" |
-| **Action Group** | Who to notify when condition is met | Email the security team |
-| **Severity** | How urgent is this? (0-4) | 2 = Warning |
-
-The alert service runs your KQL query on a schedule (every 5 minutes by default). If the query returns results, the alert "fires" and notifies your Action Group.
-
-### Severity Levels Explained
-
-| Severity | Name | When to Use | Example |
-|----------|------|-------------|---------|
-| 0 | Critical | Production down, data breach | Credential exposure detected |
-| 1 | Error | Service degraded, security incident | Sustained attack volume |
-| 2 | Warning | Needs attention soon | Spike in blocked attacks |
-| 3 | Informational | For awareness | New attack pattern seen |
-| 4 | Verbose | Debugging only | Rarely used for alerts |
-
-!!! warning "Alert Fatigue is Real"
-    The biggest mistake teams make is setting thresholds too low. If you get 50 alerts a day, you'll start ignoring them, and miss the real incidents. Start with conservative thresholds (fewer alerts) and tune down as you learn your baseline.
-
-### The Alerts We're Creating
-
-| Alert | Why This Matters |
-|-------|------------------|
-| **High Attack Volume** | A sudden spike in blocked attacks often indicates an active attack campaign. One or two blocked injections? Normal probing. Dozens in minutes? Someone's serious. |
-| **Credential Exposure** | Any credential detection is critical, even if redacted, it means sensitive data reached your system. This should wake someone up at 3 AM. |
-
-??? success "Set Up Automated Notifications"
+???+ success "Set Up Automated Notifications"
 
     Create alert rules:
 
@@ -160,28 +65,25 @@ The alert service runs your KQL query on a schedule (every 5 minutes by default)
 
     **What the script creates:**
 
-    1. **Action Group** (`mcp-security-alerts`)
-        - Short name: `MCPSecAlrt` (used in SMS notifications)
-        - Email receiver (if you provided one)
+    | Resource | Details |
+    |----------|---------|
+    | **Action Group** (`mcp-security-alerts`) | Notification list — email receiver if you provided one |
+    | **Alert: High Attack Volume** (Sev 2 — Warning) | Fires when >10 attacks in 5 minutes. Detects active campaigns. |
+    | **Alert: Credential Exposure** (Sev 1 — Error) | Fires on ANY credential detection. Critical security event. |
 
-    2. **Alert: High Attack Volume** (Severity 2 - Warning)
-        - Triggers when >10 attacks detected in 5 minutes
-        - Evaluation frequency: Every 5 minutes
-        - Use case: Detect active attack campaigns
+    Both alerts evaluate every 5 minutes. When the KQL query returns results, the alert fires and notifies your Action Group.
 
-    3. **Alert: Credential Exposure** (Severity 1 - Error)
-        - Triggers on ANY credential detection
-        - Evaluation frequency: Every 5 minutes
-        - Use case: Critical security event requiring immediate attention
+    !!! info "What's an Action Group?"
+        An Action Group is your incident response contact list — email, SMS, webhook, or even an Azure Function for automated remediation. For this workshop, we keep it simple with email (or none). In production, you'd add SMS for critical alerts and webhooks for Slack/Teams.
+
+    !!! warning "Alert Fatigue"
+        The biggest mistake teams make is setting thresholds too low. If you get 50 alerts a day, you'll start ignoring them. Start with conservative thresholds and tune down as you learn your baseline.
 
     **Verify in Azure Portal:**
 
     1. Navigate to **Monitor** → **Alerts**
     2. Click **Alert rules** to see your configured rules
-    3. After an attack simulation, check **Alerts** for fired alerts
-
-    !!! tip "Testing Alerts"
-        Alerts evaluate every 5 minutes, so there's a delay between generating events and seeing alerts fire. After running the attack simulation in Section 4, wait 5-10 minutes before checking for fired alerts.
+    3. After running the attack simulation in Section 4, wait 5-10 minutes and check for fired alerts
 
 ---
 

--- a/docs/camps/camp4-monitoring/section4-incident-response.md
+++ b/docs/camps/camp4-monitoring/section4-incident-response.md
@@ -11,61 +11,11 @@ hide:
 
 ---
 
-## Why Practice Incident Response?
-
-Building a monitoring system is one thing. Actually using it under pressure is another.
-
-Security teams practice incident response for the same reason firefighters practice drills: when the real thing happens, you don't want to be figuring things out for the first time.
-
-In this section, you'll:
-
-1. **Simulate a realistic attack** - Multiple attack vectors, realistic payloads
-2. **Watch your dashboard light up** - See the "actionable" part in action
-3. **Investigate using correlation IDs** - Trace the attack across services
-4. **Verify alerts trigger** - Confirm your automated notifications work
-
-## The Power of Correlation IDs
-
-When investigating an incident, the most valuable tool is the **correlation ID**. Here's why:
-
-A single user action might touch multiple services:
-```
-Client Request → APIM → Security Function → MCP Server → Database
-```
-
-Each service logs independently. Without correlation, you'd have:
-
-- APIM log: "Request from 203.0.113.42"
-- Function log: "Injection blocked: sql_injection"  
-- MCP Server log: "Request failed"
-
-Which function log matches which APIM request? 🤷
-
-With correlation IDs, every service logs the same ID:
-```
-APIM:     correlation_id=abc-123, CallerIP=203.0.113.42
-Function: correlation_id=abc-123, event_type=INJECTION_BLOCKED  
-MCP:      correlation_id=abc-123, status=blocked
-```
-
-Now you can instantly reconstruct the full story:
-
-```kusto
-let id = "abc-123";
-ApiManagementGatewayLogs | where CorrelationId == id
-| union (
-    AppTraces 
-    | where Properties has "correlation_id"
-    | extend CustomDims = parse_json(replace_string(replace_string(
-        tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
-    | where tostring(CustomDims.correlation_id) == id
-)
-| order by TimeGenerated
-```
+You've built the monitoring system. Now put it under pressure. This section simulates a realistic multi-vector attack so you can watch your dashboard light up, trace the attack across services, and verify your alerts fire.
 
 ## 4.1 Simulate Multi-Vector Attack
 
-??? warning "Attack Simulation"
+???+ warning "Attack Simulation"
 
     Run the attack simulation:
 
@@ -73,56 +23,51 @@ ApiManagementGatewayLogs | where CorrelationId == id
     ./scripts/section4/4.1-simulate-attack.sh
     ```
 
-    **Attack phases:**
+    The script sends attacks in phases: reconnaissance, SQL injection, path traversal, shell injection, and prompt injection. It outputs correlation IDs you can use to trace each attack.
 
-    1. **Reconnaissance** - Probe for available tools
-    2. **SQL Injection** - Multiple payload variations
-    3. **Path Traversal** - Try to access system files
-    4. **Shell Injection** - Command execution attempts
-    5. **Prompt Injection** - AI jailbreak attempts
+    **Now open your dashboard.** Go to the Azure Portal → your resource group → the Workbook you deployed in Section 3. Refresh and watch:
 
-    **What to observe:**
+    - **MCP Request Volume** spikes as attack traffic arrives
+    - **Attacks by Injection Type** breaks down exactly what was thrown at your server
+    - **Recent Security Events** shows each blocked request with its correlation ID
 
-    - Dashboard shows spike in attack volume
-    - "High Attack Volume" alert triggers
-    - Email notification (if configured)
+    This is everything you built — APIM logging, structured detection, and dashboards — working together in real time.
 
-    **Full log correlation query:**
+    !!! tip "Alerts take longer"
+        The "High Attack Volume" alert evaluates on a 5-minute window. Give it 5–10 minutes, then check your email (if you configured a notification in Section 3).
 
-    The script outputs a correlation ID. Use it to trace the attack across ALL services:
+    **Trace an attack across services:**
+
+    Copy a correlation ID from the script output and run this in Log Analytics:
 
     ```kusto
-    // Correlate attack across APIM and Function logs
-    let timeRange = ago(1h);
-    AppTraces
-    | where TimeGenerated > timeRange
-    | where Properties has "event_type"
-    | extend CustomDims = parse_json(replace_string(replace_string(
-        tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
-    | extend CorrelationId = tostring(CustomDims.correlation_id)
-    | join kind=leftouter (
-        ApiManagementGatewayLogs
-        | where TimeGenerated > timeRange
-        | where ApiId contains "mcp" or ApiId contains "sherpa"
-        | project CorrelationId, CallerIpAddress, ResponseCode
-    ) on CorrelationId
-    | project TimeGenerated, CorrelationId, 
-        EventType=tostring(CustomDims.event_type),
-        InjectionType=tostring(CustomDims.injection_type),
-        CallerIpAddress, ResponseCode
-    | order by TimeGenerated desc
-    | take 50
+    let id = "PASTE-CORRELATION-ID";
+    union
+        (ApiManagementGatewayLogs | where CorrelationId == id
+         | project TimeGenerated, Source="APIM", CorrelationId,
+                  Details=strcat("HTTP ", ResponseCode, " from ", CallerIpAddress)),
+        (AppTraces | where Properties has id
+         | extend CustomDims = parse_json(replace_string(replace_string(
+             tostring(Properties.custom_dimensions), "'", "\""), "None", "null"))
+         | where tostring(CustomDims.correlation_id) == id
+         | project TimeGenerated, Source="Function", CorrelationId=id,
+                  Details=strcat(tostring(CustomDims.event_type), ": ", tostring(CustomDims.injection_type)))
+    | order by TimeGenerated asc
     ```
+
+    This reconstructs the full story of a single request across APIM and the security function. See the [KQL Query Reference](reference.md#kql-query-reference) for more investigation queries.
 
 ---
 
 ## Cleanup
 
+When you're done with the workshop:
+
 ```bash
 # Remove all Azure resources
 azd down --force --purge
 
-# Clean up Entra ID apps (optional - ignore errors if already deleted)
+# Clean up Entra ID app registrations (ignore errors if already deleted)
 az ad app delete --id $(azd env get-value MCP_APP_CLIENT_ID)
 az ad app delete --id $(azd env get-value APIM_CLIENT_APP_ID)
 ```
@@ -131,73 +76,19 @@ az ad app delete --id $(azd env get-value APIM_CLIENT_APP_ID)
 
 ## Congratulations!
 
-You've completed Camp 4: Monitoring & Telemetry and reached **Observation Peak**! One more climb to go. The Summit awaits!
-
-### Your Journey: Hidden → Visible → Actionable
-
-Think back to where you started:
+You've completed Camp 4 and reached **Observation Peak**! Here's how far you've come:
 
 | Before | After |
 |--------|-------|
 | APIM routed traffic silently | Every request logged with caller IP, timing, correlation |
 | No AI-based attack detection | Layer 1 (Prompt Shields) blocks prompt injection at the edge |
-| Function logged basic warnings | Layer 2 structured events for SQL/path/shell with custom dimensions |
+| Function logged basic warnings | Structured events with custom dimensions and correlation IDs |
 | No way to see attack patterns | Real-time dashboard showing all attack categories |
 | Manual log checking | Automated alerts notify you of threats |
 
-You've transformed your MCP infrastructure from a "black box" into a fully observable system.
+The **hidden → visible → actionable** pattern applies beyond monitoring: whenever you deploy something new, ask yourself, "If this breaks at 3 AM, how will I know?"
 
-### What You've Accomplished
-
-:material-check: **Enabled APIM diagnostics** with GatewayLogs, GatewayLlmLogs, and WebSocketConnectionLogs  
-:material-check: **Implemented structured logging** with correlation IDs and custom dimensions  
-:material-check: **Built a security dashboard** using Azure Workbooks  
-:material-check: **Configured alert rules** for attack detection  
-:material-check: **Learned KQL** for security investigations  
-:material-check: **Practiced incident response** with cross-service log correlation
-
-### The Hidden → Visible → Actionable Pattern
-
-This pattern applies beyond just monitoring:
-
-- **Hidden problems** → Use diagnostics, logging, tracing to make them **visible**
-- **Visible data** → Use dashboards, alerts, automation to make it **actionable**
-
-Whenever you deploy something new, ask yourself: "If this breaks at 3 AM, how will I know? How will I investigate?"
-
-### Skills You've Gained
-
-| Skill | What You Can Now Do |
-|-------|---------------------|
-| **Azure Monitor** | Configure diagnostic settings, use Log Analytics |
-| **KQL** | Write queries to investigate security events |
-| **Structured Logging** | Design log events that are queryable at scale |
-| **Dashboarding** | Build Workbooks for security visualization |
-| **Alerting** | Create rules that notify on security thresholds |
-| **Incident Response** | Trace requests across services using correlation IDs |
-
----
-
-## Almost at the Summit!
-
-You've completed all four skill-building camps:
-
-| Camp | What You Secured |
-|------|------------------|
-| **Base Camp** | Understanding MCP vulnerabilities |
-| **Camp 1: Identity** | OAuth 2.0 + Entra ID authentication |
-| **Camp 2: Gateway** | APIM protection + rate limiting |
-| **Camp 3: I/O Security** | Input validation + output sanitization |
-| **Camp 4: Monitoring** | Full observability + alerting |
-
-Your MCP servers are now **authenticated**, **protected**, **validated**, and **observable**.
-
-!!! tip "What's Next: The Summit"
-    You've learned all the individual security skills. Now it's time to put them all together!
-    
-    The **Summit** is where you'll deploy the complete secure MCP infrastructure and test it with realistic red team / blue team exercises.
-
-**One more climb to go!**
+Your MCP servers are now **authenticated**, **protected**, **validated**, and **observable**. One more climb to go!
 
 ---
 


### PR DESCRIPTION
- index.md: trim grid cards, roadmap table, redundant sections
- section1: replace ASCII diagram with table, expand steps, remove duplicate field tables
- section2: expand steps, consolidate KQL to 1 query + Reference link, remove ASCII diagram
- section3: fix dashboard panel table, add workshop vs production info, consolidate alert details
- section4: emphasize dashboard payoff, remove duplicate correlation ID section, conditional cleanup
- production-deploy: expand collapsible, fix cleanup to use conditional app deletion
- reference: replace 4 ASCII diagrams with tables, add common parse pattern note, expand troubleshooting