### PR TITLE
fix: update documentation path for AI Gateway in content safety section

### DIFF
--- a/docs/camps/camp2-gateway/section2-content-safety.md
+++ b/docs/camps/camp2-gateway/section2-content-safety.md
@@ -245,7 +245,7 @@ In this section, you'll use [Azure AI Content Safety](https://learn.microsoft.co
 
     **3. Check the policy on your MCP API:**
 
-    Go to: **APIs** → **MCP Servers** → Select an API → **Policies**
+    Go to: **AI Gateway** → **MCP Servers** → Select an API → **Policies**
 
     You should see:
 


### PR DESCRIPTION
This pull request makes a minor update to the documentation to clarify navigation instructions. The section now correctly refers to the "AI Gateway" instead of "APIs" in the UI path for accessing MCP Server policies.

- Documentation update:
  * Updated the navigation path in the content safety section to reference **AI Gateway** instead of **APIs** for finding MCP Server policies.