### PR TITLE
docs(camp2): correct Sherpa MCP server tool names

### DIFF
--- a/docs/camps/camp2-gateway/section1-gateway-governance.md
+++ b/docs/camps/camp2-gateway/section1-gateway-governance.md
@@ -100,8 +100,8 @@ Without authentication, your MCP server is completely open to the internet. For 
         **Sherpa** is a FastMCP server that provides mountain expedition tools:
 
         - `get_weather` - Current weather conditions at different elevations
-        - `list_trails` - Available climbing routes and difficulty ratings
-        - `check_gear` - Verify required equipment for specific conditions
+        - `check_trail_conditions` - Trail status and hazards for a specific route
+        - `get_gear_recommendations` - Recommended equipment for specific conditions
 
         **Why read-only?** Sherpa only exposes read operations (queries) with no write capabilities (no data modification, file system access, or system commands). This follows a key [enterprise pattern](https://microsoft.github.io/mcp-azure-security-guide/adoption/enterprise-patterns/#lessons-from-early-adopters): **separate read from write operations**. Read-only MCP servers are safer for demos and initial deployments because they limit the blast radius of potential exploits. Once you've validated security controls at the gateway (authentication, rate limiting, content safety), you can confidently add write operations or deploy separate write-enabled MCP servers with stricter controls.
 


### PR DESCRIPTION
## Summary

The "What is the Sherpa MCP Server?" callout in Camp 2 Section 1 listed two tools that don't exist in the actual server implementation. This corrects the list to match `camps/camp2-gateway/servers/sherpa-mcp-server/src/server.py`.

## Changes

| Doc (before) | Actual tool (after) |
|--------------|---------------------|
| `list_trails` | `check_trail_conditions` |
| `check_gear` | `get_gear_recommendations` |

`get_weather` was already correct. The Step 2 exploit section already referenced the correct names, so this brings the callout into agreement with the rest of the page.

## Verification

Tool names confirmed against the `@mcp.tool()` definitions in [server.py](../blob/main/camps/camp2-gateway/servers/sherpa-mcp-server/src/server.py).