### PR TITLE
Add SEO metadata and robots.txt for workshop documentation

### DIFF
--- a/docs/camps/base-camp.md
+++ b/docs/camps/base-camp.md
@@ -1,4 +1,7 @@
 ---
+title: "Base Camp: MCP Fundamentals & First Exploit"
+description: "Start here. Learn Model Context Protocol (MCP) fundamentals, run a deliberately vulnerable MCP server, exploit it, then apply the security fixes in this beginner-friendly Microsoft workshop."
+keywords: Microsoft, MCP fundamentals, Model Context Protocol, MCP security basics, vulnerable MCP server, OWASP MCP, FastMCP, Azure
 hide:
   - toc
 ---

--- a/docs/camps/camp1-identity/index.md
+++ b/docs/camps/camp1-identity/index.md
@@ -1,4 +1,7 @@
 ---
+title: "Camp 1: Identity & Access for MCP Servers on Azure"
+description: "Secure MCP servers with enterprise identity on Azure. Deploy to Container Apps and apply Managed Identity, Key Vault, and OAuth 2.1 with JWT validation in this beginner-friendly Microsoft guide."
+keywords: Microsoft, Entra ID, Managed Identity, Key Vault, OAuth 2.1, JWT validation, Azure Container Apps, MCP authentication
 hide:
   - toc
 ---

--- a/docs/camps/camp1-identity/section1-cloud-exploits.md
+++ b/docs/camps/camp1-identity/section1-cloud-exploits.md
@@ -1,4 +1,7 @@
 ---
+title: Exploit MCP Cloud Identity Vulnerabilities
+description: "See why static tokens are dangerous on Azure: tokens exposed in the Portal that never expire, and missing JWT audience validation that enables confused deputy attacks."
+keywords: Microsoft, static token, JWT audience validation, confused deputy attack, MCP token exposure, Azure identity
 hide:
   - toc
 ---

--- a/docs/camps/camp1-identity/section2-managed-identity.md
+++ b/docs/camps/camp1-identity/section2-managed-identity.md
@@ -1,4 +1,7 @@
 ---
+title: Enable Managed Identity for MCP Servers
+description: "Replace connection strings with passwordless Azure Managed Identity so Container Apps reach Azure resources securely using RBAC and DefaultAzureCredential."
+keywords: Microsoft, Azure Managed Identity, passwordless authentication, RBAC, DefaultAzureCredential, Container Apps
 hide:
   - toc
 ---

--- a/docs/camps/camp1-identity/section3-key-vault.md
+++ b/docs/camps/camp1-identity/section3-key-vault.md
@@ -1,4 +1,7 @@
 ---
+title: Migrate MCP Secrets to Azure Key Vault
+description: "Move secrets out of environment variables into Azure Key Vault and retrieve them at runtime via Managed Identity, with auditing, rotation, and versioning."
+keywords: Microsoft, Azure Key Vault, secret management, secret rotation, secret versioning, Managed Identity, RBAC
 hide:
   - toc
 ---

--- a/docs/camps/camp1-identity/section4-oauth-jwt.md
+++ b/docs/camps/camp1-identity/section4-oauth-jwt.md
@@ -1,4 +1,7 @@
 ---
+title: OAuth 2.1 & JWT Validation for MCP Servers
+description: "Replace static tokens with short-lived, signed JWTs from Entra ID. Validate signature, audience, issuer, and expiry, with Device Code and Authorization Code PKCE flows."
+keywords: Microsoft, OAuth 2.1, JWT validation, Entra ID, PKCE, Device Code flow, Protected Resource Metadata, RFC 9728
 hide:
   - toc
 ---

--- a/docs/camps/camp1-identity/section5-validate.md
+++ b/docs/camps/camp1-identity/section5-validate.md
@@ -1,4 +1,7 @@
 ---
+title: Validate MCP Identity Security on Azure
+description: "Run automated checks to confirm secrets live in Key Vault, Managed Identity has the right RBAC, tokens expire, and no credentials leak into environment variables."
+keywords: Microsoft, security validation, Key Vault, Managed Identity RBAC, token expiration, audience validation
 hide:
   - toc
 ---

--- a/docs/camps/camp2-gateway/api-governance.md
+++ b/docs/camps/camp2-gateway/api-governance.md
@@ -1,4 +1,7 @@
 ---
+title: MCP Governance with Azure API Center
+description: "Register and govern MCP servers centrally with Azure API Center to prevent shadow deployments, enable discovery, and track compliance."
+keywords: Microsoft, Azure API Center, MCP governance, API governance, shadow server, API discovery, compliance
 hide:
   - toc
 ---

--- a/docs/camps/camp2-gateway/index.md
+++ b/docs/camps/camp2-gateway/index.md
@@ -1,4 +1,7 @@
 ---
+title: "Camp 2: API Management Gateway for MCP Servers"
+description: "Put multiple MCP servers behind Azure API Management for centralized OAuth, rate limiting, content safety, and governance in this beginner-friendly Microsoft guide."
+keywords: Microsoft, Azure API Management, APIM, MCP gateway, rate limiting, API Center, AI Content Safety
 hide:
   - toc
 ---

--- a/docs/camps/camp2-gateway/section1-gateway-governance.md
+++ b/docs/camps/camp2-gateway/section1-gateway-governance.md
@@ -1,4 +1,7 @@
 ---
+title: MCP Gateway Authentication with Azure APIM
+description: "Expose MCP servers through Azure API Management with OAuth 2.1 validation, automatic OAuth discovery via Protected Resource Metadata, and rate-limiting policies."
+keywords: Microsoft, Azure API Management, APIM, OAuth 2.1, JWT validation, rate limiting, Protected Resource Metadata
 hide:
   - toc
 ---

--- a/docs/camps/camp2-gateway/section2-content-safety.md
+++ b/docs/camps/camp2-gateway/section2-content-safety.md
@@ -1,4 +1,7 @@
 ---
+title: Block Prompt Injection with Azure AI Content Safety
+description: "Apply Azure AI Content Safety Prompt Shields at the APIM gateway to detect and block prompt injection and jailbreak attacks before they reach MCP backends."
+keywords: Microsoft, Azure AI Content Safety, Prompt Shields, prompt injection, jailbreak detection, APIM policy
 hide:
   - toc
 ---

--- a/docs/camps/camp2-gateway/section3-network-security.md
+++ b/docs/camps/camp2-gateway/section3-network-security.md
@@ -1,4 +1,7 @@
 ---
+title: Network Isolation for MCP Servers on Azure
+description: "Prevent direct backend access that bypasses the APIM gateway using IP restrictions, VNet integration, private endpoints, NSGs, and header validation."
+keywords: Microsoft, network isolation, Azure Virtual Network, private endpoints, NSG, Private Link, APIM
 hide:
   - toc
 ---

--- a/docs/camps/camp3-io-security/index.md
+++ b/docs/camps/camp3-io-security/index.md
@@ -1,4 +1,7 @@
 ---
+title: "Camp 3: Input & Output Security for MCP Servers"
+description: "Add a Layer 2 security middleware with Azure Functions in APIM to validate inputs and sanitize outputs, blocking injection attacks and PII leakage. A beginner-friendly Microsoft guide."
+keywords: Microsoft, input validation, output sanitization, injection attacks, PII redaction, Azure Functions, APIM
 hide:
   - toc
 ---

--- a/docs/camps/camp3-io-security/section1-vulnerabilities.md
+++ b/docs/camps/camp3-io-security/section1-vulnerabilities.md
@@ -1,4 +1,7 @@
 ---
+title: MCP Injection & PII Vulnerabilities Explained
+description: "Run exploits showing how Content Safety misses shell, SQL, and path traversal injection, and how MCP servers can leak unredacted PII (OWASP MCP05, MCP06, MCP10)."
+keywords: Microsoft, shell injection, SQL injection, path traversal, PII leakage, OWASP MCP, Content Safety limitations
 hide:
   - toc
 ---

--- a/docs/camps/camp3-io-security/section2-layer2-security.md
+++ b/docs/camps/camp3-io-security/section2-layer2-security.md
@@ -1,4 +1,7 @@
 ---
+title: Layer 2 MCP Security with Azure Functions
+description: "Wire Azure Functions into APIM policies for hybrid detection that combines fast regex checks with AI-powered Prompt Shields, input validation, and PII redaction."
+keywords: Microsoft, Azure Functions, APIM policy, input validation, output sanitization, PII redaction, Prompt Shields
 hide:
   - toc
 ---

--- a/docs/camps/camp3-io-security/section3-validation.md
+++ b/docs/camps/camp3-io-security/section3-validation.md
@@ -1,4 +1,7 @@
 ---
+title: Validate MCP I/O Security & Defense in Depth
+description: "Re-run the exploits to confirm injection and PII attacks are blocked, then learn how to deploy sanitization for native FastMCP versus synthesized MCP servers."
+keywords: Microsoft, defense in depth, output sanitization, APIM outbound policy, fail-open, fail-closed, FastMCP
 hide:
   - toc
 ---

--- a/docs/camps/camp4-monitoring/index.md
+++ b/docs/camps/camp4-monitoring/index.md
@@ -1,4 +1,7 @@
 ---
+title: "Camp 4: Monitoring & Telemetry for MCP Security"
+description: "Deploy Log Analytics and Application Insights for full observability of your MCP security controls, so you can detect attacks, prove defenses work, and alert on events. A beginner-friendly Microsoft guide."
+keywords: Microsoft, Log Analytics, Application Insights, Azure Monitor, observability, MCP monitoring, telemetry
 hide:
   - toc
 ---

--- a/docs/camps/camp4-monitoring/production-deploy.md
+++ b/docs/camps/camp4-monitoring/production-deploy.md
@@ -1,4 +1,7 @@
 ---
+title: Deploy the Full MCP Observability Stack
+description: "Provision Camp 4's complete observability stack (diagnostics, structured logging, dashboards, and alerts) in a single azd command with DEPLOY_MODE=complete."
+keywords: Microsoft, azd deploy, DEPLOY_MODE, Bicep, observability stack, structured logging, Azure Monitor
 hide:
   - toc
 ---

--- a/docs/camps/camp4-monitoring/reference.md
+++ b/docs/camps/camp4-monitoring/reference.md
@@ -1,4 +1,7 @@
 ---
+title: KQL & Azure Monitor Reference for MCP Security
+description: "A KQL primer and reference for MCP security monitoring: operators, log table schemas, custom dimensions, correlation IDs, and ready-made investigation queries."
+keywords: Microsoft, KQL, Azure Monitor, Log Analytics schema, custom dimensions, correlation ID, query reference
 hide:
   - toc
 ---

--- a/docs/camps/camp4-monitoring/section1-apim-logging.md
+++ b/docs/camps/camp4-monitoring/section1-apim-logging.md
@@ -1,4 +1,7 @@
 ---
+title: APIM Gateway Logging with Log Analytics
+description: "Configure Azure API Management diagnostic settings to stream HTTP and LLM logs to Log Analytics, then query gateway traffic with KQL."
+keywords: Microsoft, APIM diagnostic settings, GatewayLogs, GatewayLlmLogs, Log Analytics, KQL, correlation ID
 hide:
   - toc
 ---

--- a/docs/camps/camp4-monitoring/section2-function-observability.md
+++ b/docs/camps/camp4-monitoring/section2-function-observability.md
@@ -1,4 +1,7 @@
 ---
+title: Structured Security Telemetry for Azure Functions
+description: "Upgrade the security function to structured logging with Application Insights OpenTelemetry, emitting queryable security events with custom dimensions."
+keywords: Microsoft, structured logging, custom dimensions, Application Insights, OpenTelemetry, AppTraces, observability
 hide:
   - toc
 ---

--- a/docs/camps/camp4-monitoring/section3-dashboards-alerts.md
+++ b/docs/camps/camp4-monitoring/section3-dashboards-alerts.md
@@ -1,4 +1,7 @@
 ---
+title: MCP Security Dashboards & Alerts in Azure Monitor
+description: "Deploy an interactive Azure Workbook dashboard and create Azure Monitor alert rules that email you on high attack volume or credential exposure."
+keywords: Microsoft, Azure Workbooks, Azure Monitor alerts, action groups, security dashboard, attack monitoring
 hide:
   - toc
 ---

--- a/docs/camps/camp4-monitoring/section4-incident-response.md
+++ b/docs/camps/camp4-monitoring/section4-incident-response.md
@@ -1,4 +1,7 @@
 ---
+title: MCP Incident Response & Attack Correlation
+description: "Simulate a multi-vector attack, watch the dashboard respond, and trace attacks across APIM and Azure Functions using correlation IDs and KQL."
+keywords: Microsoft, incident response, multi-vector attack, correlation ID, KQL, attack tracing, Azure Monitor
 hide:
   - toc
 ---

--- a/docs/camps/summit.md
+++ b/docs/camps/summit.md
@@ -1,4 +1,7 @@
 ---
+title: "The Summit: Production-Ready Secure MCP on Azure"
+description: "The capstone of the Microsoft MCP Security Workshop: combine identity, gateway, I/O security, and monitoring into a production-ready, secure Model Context Protocol deployment on Azure."
+keywords: Microsoft, secure MCP production, MCP architecture, Azure MCP security, Model Context Protocol, defense in depth
 hide:
   - toc
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 title: MCP Security Summit Workshop
-description: Secure MCP servers in Azure through hands-on exploitation and remediation. Break things, fix them, ship production-ready code — with Entra ID, Key Vault, API Management, AI Content Safety, and Log Analytics.
-keywords: MCP, Model Context Protocol, Azure security, Entra ID, API Management, AI Content Safety, OWASP, workshop
+description: "Official, beginner-friendly Microsoft workshop for securing Model Context Protocol (MCP) servers on Azure with Entra ID, Key Vault, API Management, AI Content Safety, and monitoring."
+keywords: MCP security, Model Context Protocol, Microsoft MCP, Azure security, Entra ID, API Management, AI Content Safety, OWASP, secure MCP server, beginner workshop
 image: https://azure-samples.github.io/sherpa/images/sherpa-mcp-workshop.png
 hide_page_header: true
 hide:

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,6 +1,7 @@
 ---
-title: Prerequisites
-description: Tools, accounts, and setup you'll need before starting any camp in the MCP Security Summit Workshop.
+title: Prerequisites & Setup
+description: "Install and verify the tools you need for the Microsoft MCP Security Workshop: Azure subscription, Python, uv, Azure CLI, azd, Docker, and VS Code."
+keywords: Microsoft, MCP workshop setup, Azure CLI, azd, Python, uv, Docker, prerequisites, Azure subscription
 hide_page_header: true
 ---
 

--- a/docs/resources/contributing.md
+++ b/docs/resources/contributing.md
@@ -1,6 +1,7 @@
 ---
 title: Contributing
-description: How to contribute to the MCP Security Summit Workshop.
+description: "How to contribute to the Microsoft MCP Security Workshop: the exploit-fix-validate methodology, Bash and PowerShell script parity, MkDocs conventions, and code style."
+keywords: Microsoft, contributing, MCP workshop, Bash, PowerShell, MkDocs, code style, exploit-fix-validate
 hide_page_header: true
 ---
 

--- a/docs/resources/infrastructure.md
+++ b/docs/resources/infrastructure.md
@@ -1,3 +1,9 @@
+---
+title: Infrastructure Setup
+description: "Shared Bicep templates and deployment automation for the Microsoft MCP Security Workshop, with Azure resource naming and cost guidance (under development)."
+keywords: Microsoft, Bicep, Azure infrastructure, deployment automation, resource naming, cost management
+---
+
 # Infrastructure Setup
 
 ## Overview

--- a/docs/resources/scripts.md
+++ b/docs/resources/scripts.md
@@ -1,3 +1,9 @@
+---
+title: Workshop Scripts
+description: "Automation scripts for the Microsoft MCP Security Workshop, including Azure provisioning, cleanup, and environment validation (under development)."
+keywords: Microsoft, MCP workshop scripts, Azure automation, provisioning, cleanup, environment validation
+---
+
 # Workshop Scripts
 
 ## Overview

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://azure-samples.github.io/sherpa/sitemap.xml


### PR DESCRIPTION
This pull request adds SEO metadata (titles, descriptions, and keywords) to all documentation pages in the `docs/camps` directory. The metadata is tailored for each page to improve discoverability and clarity for users searching for Microsoft MCP security workshops and related Azure topics.

## Summary

Adds per-page SEO metadata across the workshop docs so search engines and social previews work on every page (previously only the homepage carried metadata).

## Changes
- Add title, description, and keywords frontmatter to all docs pages. The theme cascades these into the meta description, Open Graph, Twitter Card, and JSON-LD.
- Position the site as a beginner-friendly Microsoft MCP security workshop in descriptions and keywords.
- Add docs/robots.txt referencing the sitemap.

## Verification
- mkdocs build --clean succeeds with no errors.
- Confirmed rendered <title>, meta description, keywords, OG, and JSON-LD on interior pages.